### PR TITLE
chore: specify node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- require Node.js >=20.19.0 via package.json engines field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68aeb2a40c5c832e81d804720a8a10af