### PR TITLE
feat: add release notes page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, an admin dashboard, and an admin charts screen. Pages live under `src/pages` and a shared layout under `src/app`.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, an admin dashboard, an admin charts screen, and a release notes page. Pages live under `src/pages` and a shared layout under `src/app`.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -26,8 +26,9 @@ _Only this section of the readme can be maintained using Russian language_
   - [ ] 3.2.2 Создать страницу /admin/dev/charts/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
 
 6. Удобства
-  - [ ] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.
+  - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.
   - [ ] 6.2 Создать страницу /release-notes где задействовать release-notes.json вверху страницы расположить sticky компонент для управления отображением релизов(HMR). В компоненте распложить:
+  - - [x] 6.2.0 Реализовать базовый вывод релизов по времени.
   - - [ ] 6.2.1 Переключатель: релизы только по времени или релизы только по дням или кратчайшие релизы. Состояние переключателя при переключение сохранять в localstorage. (Создать /servises/localstorageHelper.jsx для лаконичного взаимодействия с localstorage.)
 
 
@@ -54,6 +55,7 @@ _Only this section of the readme can be maintained using Russian language_
 10. After completing a task, suggest the next task to complete (don't add this to readme).
 11. Keep the "ACP+Charts now" section up to date by showing only what is already available in the project from the user's perspective. Display the current version: {release_number}.
 12. If there is no indication what language the page should be in, use English.
+13. Update `release-notes.json` for every user-facing change according to `release-notes-howto.md`.
  
 # Project details
 
@@ -65,3 +67,8 @@ _Only this section of the readme can be maintained using Russian language_
 ## Tech and infrastructure
 - React + Vite (fast HMR).
 - Railway is our hosting.
+
+## Release notes
+- File `release-notes.json` follows [release-notes-howto.md](release-notes-howto.md).
+- Each user-facing change must append a bilingual entry with ISO 8601 timestamp.
+- Keep entries sorted chronologically and update daily summaries and the ultrashort digest.

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,0 +1,38 @@
+{
+  "version": "0.0.0",
+  "generated": "2025-08-28T09:35:54+00:00",
+  "changes": [
+    {
+      "id": "2025-08-28T09:35:00+00:00-docs-docs",
+      "timestamp": "2025-08-28T09:35:00+00:00",
+      "version": "0.0.0",
+      "type": "docs",
+      "scope": "docs",
+      "description": {
+        "en": "Document release notes rules",
+        "ru": "Добавлены правила ведения release notes"
+      }
+    },
+    {
+      "id": "2025-08-28T09:35:30+00:00-feat-ui",
+      "timestamp": "2025-08-28T09:35:30+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Add release notes page",
+        "ru": "Добавлена страница release notes"
+      }
+    }
+  ],
+  "daily": {
+    "2025-08-28": {
+      "en": "Release notes page and rules added",
+      "ru": "Добавлена страница release notes и правила ведения"
+    }
+  },
+  "ultrashort": {
+    "en": "Release notes page online",
+    "ru": "Появилась страница release notes"
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import Layout from './app/layout.jsx'
 import MainPage from './pages/mainPage.jsx'
 import AdminPage from './pages/adminPage.jsx'
 import AdminChartsPage from './pages/adminChartsPage.jsx'
+import ReleaseNotesPage from './pages/releaseNotesPage.jsx'
 
 const router = createBrowserRouter([
   {
@@ -15,6 +16,7 @@ const router = createBrowserRouter([
       { index: true, element: <MainPage /> },
       { path: 'admin', element: <AdminPage /> },
       { path: 'admin/charts', element: <AdminChartsPage /> },
+      { path: 'release-notes', element: <ReleaseNotesPage /> },
     ],
   },
 ])

--- a/src/pages/releaseNotesPage.jsx
+++ b/src/pages/releaseNotesPage.jsx
@@ -1,0 +1,32 @@
+import releaseNotes from '../../release-notes.json'
+
+export default function ReleaseNotesPage() {
+  const changes = [...releaseNotes.changes].sort(
+    (a, b) => new Date(b.timestamp) - new Date(a.timestamp),
+  )
+  const groups = changes.reduce((acc, change) => {
+    const date = change.timestamp.slice(0, 10)
+    if (!acc[date]) acc[date] = []
+    acc[date].push(change)
+    return acc
+  }, {})
+  const dates = Object.keys(groups).sort((a, b) => new Date(b) - new Date(a))
+  return (
+    <div>
+      {dates.map(date => (
+        <div key={date}>
+          <h2>{date}</h2>
+          {groups[date]
+            .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+            .map(item => (
+              <div key={item.id}>
+                <h3>{item.timestamp.slice(11, 16)}</h3>
+                <p>{item.description.en}</p>
+                <p>{item.description.ru}</p>
+              </div>
+            ))}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add release notes page
- track changes in new release-notes.json
- document release notes maintenance rules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `jq . release-notes.json`

------
https://chatgpt.com/codex/tasks/task_e_68b022984b98832eb23f6f53818005c3