### PR TITLE
feat: separate user and admin menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, an admin dashboard, an admin charts screen, and a release notes page showing updates in English. Pages live under `src/pages` and a shared layout under `src/app`.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, an admin dashboard, an admin charts screen, and a release notes page showing updates in English. Pages live under `src/pages` and a shared layout under `src/app`. Non-admin pages display a user menu, while admin pages use a separate admin menu.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -26,7 +26,7 @@ _Only this section of the readme can be maintained using Russian language_
   - [ ] 3.2.2 Создать страницу /admin/dev/charts/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
 
 6. Удобства
-  - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.
+ - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.
   - [ ] 6.2 Создать страницу /release-notes где задействовать release-notes.json вверху страницы расположить sticky компонент для управления отображением релизов(HMR). В компоненте распложить:
   - - [x] 6.2.0 Реализовать базовый вывод релизов по времени.
   - - [ ] 6.2.1 Переключатель: релизы только по времени или релизы только по дням или кратчайшие релизы. Состояние переключателя при переключение сохранять в localstorage. (Создать /servises/localstorageHelper.jsx для лаконичного взаимодействия с localstorage.)
@@ -36,7 +36,10 @@ _Only this section of the readme can be maintained using Russian language_
   - 7.15 Принципы
     - Асинхронность
     - Try-catch
-
+8. Меню
+  - [x] 8.1 Создать компонент barLeftUser со ссылками на все страницы.
+  - [x] 8.2 Создать компонент barLeftAdmin (пустой).
+  - [x] 8.3 Подключить barLeftUser на всех страницах кроме /admin/*, barLeftAdmin на /admin/*.
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "generated": "2025-08-28T20:28:48+00:00",
+  "generated": "2025-08-28T20:57:46+00:00",
   "changes": [
     {
       "id": "2025-08-28T09:35:00+00:00-docs-docs",
@@ -45,16 +45,27 @@
         "en": "Limited release notes page to English",
         "ru": "Страница release notes отображает только английский текст"
       }
+    },
+    {
+      "id": "2025-08-28T20:57:30+00:00-feat-ui",
+      "timestamp": "2025-08-28T20:57:30+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Separated user and admin menus",
+        "ru": "Разделены меню пользователя и админа"
+      }
     }
   ],
   "daily": {
     "2025-08-28": {
-      "en": "Release notes page shows English only; rules and style clarified",
-      "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль"
+      "en": "Release notes page shows English only; rules and style clarified; separated user and admin menus",
+      "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only",
-    "ru": "Release notes только на английском"
+    "en": "Release notes English-only; split user/admin menus",
+    "ru": "Release notes только на английском; разделены меню"
   }
 }

--- a/src/app/barLeftAdmin.jsx
+++ b/src/app/barLeftAdmin.jsx
@@ -1,0 +1,3 @@
+export default function BarLeftAdmin() {
+  return <nav></nav>
+}

--- a/src/app/barLeftUser.jsx
+++ b/src/app/barLeftUser.jsx
@@ -1,0 +1,9 @@
+import { Link } from 'react-router-dom'
+
+export default function BarLeftUser() {
+  return (
+    <nav>
+      <Link to="/">Main</Link> | <Link to="/admin">Admin</Link> | <Link to="/admin/charts">Admin Charts</Link> | <Link to="/release-notes">Release Notes</Link>
+    </nav>
+  )
+}

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,12 +1,13 @@
-import { Link, Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
+import BarLeftUser from './barLeftUser.jsx'
+import BarLeftAdmin from './barLeftAdmin.jsx'
 
 export default function Layout() {
+  const location = useLocation()
+  const isAdminRoute = location.pathname.startsWith('/admin')
   return (
     <>
-      <nav>
-        <Link to="/">Main</Link> | <Link to="/admin">Admin</Link> |{' '}
-        <Link to="/admin/charts">Admin Charts</Link>
-      </nav>
+      {isAdminRoute ? <BarLeftAdmin /> : <BarLeftUser />}
       <Outlet />
     </>
   )


### PR DESCRIPTION
## Summary
- add `barLeftUser` with links to all pages and empty `barLeftAdmin`
- switch layout to use user or admin menu based on route
- document menu components in README and release notes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c27a0738832e80ed956e50cfa78c