### PR TITLE
fix: refine sidebar icon layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 8.1 Создать компонент barLeftUser со ссылками на все страницы.
   - [x] 8.2 Создать компонент barLeftAdmin (пустой).
   - [x] 8.3 Подключить barLeftUser на всех страницах кроме /admin/*, barLeftAdmin на /admin/*.
+  - [x] 8.4 Уточнить порядок и расстояния иконок в сайдбаре пользователя.
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/release-notes.json
+++ b/release-notes.json
@@ -56,8 +56,7 @@
         "en": "Separated user and admin menus",
         "ru": "Разделены меню пользователя и админа"
       }
-    }
-    ,
+    },
     {
       "id": "2025-08-28T21:43:30+00:00-feat-ui",
       "timestamp": "2025-08-28T21:43:30+00:00",
@@ -68,16 +67,27 @@
         "en": "Added collapsible user sidebar",
         "ru": "Добавлен сворачиваемый сайдбар пользователя"
       }
+    },
+    {
+      "id": "2025-08-28T21:56:43+00:00-feat-ui",
+      "timestamp": "2025-08-28T21:56:43+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Darkened sidebar background and fixed icon order",
+        "ru": "Утемнён фон сайдбара и закреплён порядок иконок"
+      }
     }
   ],
   "daily": {
     "2025-08-28": {
-      "en": "Release notes page shows English only; rules and style clarified; separated user and admin menus; added collapsible user sidebar",
-      "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар"
+      "en": "Release notes page shows English only; rules and style clarified; separated user and admin menus; added collapsible user sidebar; darkened sidebar and stabilized icons",
+      "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; darkened sidebar icons",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; затемнён иконки в сайдбаре"
   }
 }

--- a/src/app/barLeftUser.css
+++ b/src/app/barLeftUser.css
@@ -7,22 +7,23 @@
   width: 250px;
   transition: width 0.3s ease;
   scrollbar-width: none;
+  background-color: #f0f0f0;
 }
 .sidebar-left::-webkit-scrollbar {
   display: none;
 }
 .sidebar-left.collapsed {
-  width: 20px;
+  width: 32px;
   padding: 0;
 }
 .sidebar-header {
   display: flex;
-  flex-direction: row-reverse;
-  gap: 4px;
+  flex-direction: row;
+  gap: 0;
 }
 .icon-button {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -35,8 +36,8 @@
 .sidebar-content {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 8px;
+  gap: 4px;
+  padding: 4px;
 }
 .sidebar-left.collapsed .sidebar-content {
   display: none;


### PR DESCRIPTION
## Summary
- darken sidebar background and keep toggle icon first
- tighten sidebar icon spacing for minimal movement
- document task in Features ToDo and release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d03a2f50832ea9f746829546327b