### PR TITLE
feat: add dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 8.4 Уточнить порядок и расстояния иконок в сайдбаре пользователя.
 
 9. Документация
-  - [x] 9.1 Перечислить все используемые библиотеки в readme.
+ - [x] 9.1 Перечислить все используемые библиотеки в readme.
+
+10. Тёмная тема
+ - [x] 10.1 Распознавать prefers-color-scheme для автоматического переключения темы.
+ - [x] 10.2 Применить тёмную палитру для сайдбара и интерфейса.
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <style>
+      html {
+        background-color: #ffffff;
+        color: #213547;
+      }
+      @media (prefers-color-scheme: dark) {
+        html {
+          background-color: #242424;
+          color: rgba(255, 255, 255, 0.87);
+        }
+      }
+    </style>
     <title>Vite + React</title>
   </head>
   <body>

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "generated": "2025-08-28T21:43:48+00:00",
+  "generated": "2025-08-28T22:08:00+00:00",
   "changes": [
     {
       "id": "2025-08-28T09:35:00+00:00-docs-docs",
@@ -78,16 +78,27 @@
         "en": "Darkened sidebar background and fixed icon order",
         "ru": "Утемнён фон сайдбара и закреплён порядок иконок"
       }
+    },
+    {
+      "id": "2025-08-28T22:08:00+00:00-feat-ui",
+      "timestamp": "2025-08-28T22:08:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Implemented dark mode with consistent palette",
+        "ru": "Реализован тёмный режим с согласованной палитрой"
+      }
     }
   ],
   "daily": {
     "2025-08-28": {
-      "en": "Release notes page shows English only; rules and style clarified; separated user and admin menus; added collapsible user sidebar; darkened sidebar and stabilized icons",
-      "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки"
+      "en": "Release notes page shows English only; rules and style clarified; separated user and admin menus; added collapsible user sidebar; darkened sidebar and stabilized icons; implemented dark mode",
+      "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; darkened sidebar icons",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; затемнён иконки в сайдбаре"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим"
   }
 }

--- a/src/app/barLeftUser.css
+++ b/src/app/barLeftUser.css
@@ -6,11 +6,19 @@
   overflow-x: hidden;
   width: 250px;
   transition: width 0.3s ease;
-  scrollbar-width: none;
-  background-color: #f0f0f0;
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border-right: 1px solid var(--color-border);
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
 }
 .sidebar-left::-webkit-scrollbar {
-  display: none;
+  width: 8px;
+}
+.sidebar-left::-webkit-scrollbar-thumb {
+  background-color: var(--color-scrollbar-thumb);
+}
+.sidebar-left::-webkit-scrollbar-track {
+  background-color: var(--color-scrollbar-track);
 }
 .sidebar-left.collapsed {
   width: 32px;
@@ -29,15 +37,17 @@
   justify-content: center;
   cursor: pointer;
   transition: background-color 0.3s ease;
+  color: var(--color-text);
 }
 .icon-button:hover {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--color-hover);
 }
 .sidebar-content {
   display: flex;
   flex-direction: column;
   gap: 4px;
   padding: 4px;
+  color: var(--color-text);
 }
 .sidebar-left.collapsed .sidebar-content {
   display: none;

--- a/src/index.css
+++ b/src/index.css
@@ -2,24 +2,35 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --color-bg: #ffffff;
+  --color-text: #213547;
+  --color-surface: #f0f0f0;
+  --color-border: #d0d0d0;
+  --color-link: #646cff;
+  --color-link-hover: #535bf2;
+  --color-hover: rgba(0, 0, 0, 0.1);
+  --color-scrollbar-thumb: #c1c1c1;
+  --color-scrollbar-track: #e0e0e0;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #242424;
+    --color-text: rgba(255, 255, 255, 0.87);
+    --color-surface: #1e1e1e;
+    --color-border: #3a3a3a;
+    --color-link: #9b9eff;
+    --color-link-hover: #b0b4ff;
+    --color-hover: rgba(255, 255, 255, 0.1);
+    --color-scrollbar-thumb: #555555;
+    --color-scrollbar-track: #2b2b2b;
+  }
 }
 
 body {
@@ -28,11 +39,31 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+body::-webkit-scrollbar {
+  width: 8px;
+}
+
+body::-webkit-scrollbar-thumb {
+  background-color: var(--color-scrollbar-thumb);
+}
+
+body::-webkit-scrollbar-track {
+  background-color: var(--color-scrollbar-track);
+}
+
+a {
+  font-weight: 500;
+  color: var(--color-link);
+  text-decoration: inherit;
+}
+
+a:hover {
+  color: var(--color-link-hover);
 }
 
 button {
@@ -42,27 +73,35 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-surface);
+  color: var(--color-text);
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: border-color 0.25s, background-color 0.25s;
 }
+
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-link);
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+h1 {
+  font-size: 3.2em;
+  line-height: 1.1;
 }
+
+header {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border);
+}
+
+dialog {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+


### PR DESCRIPTION
## Summary
- detect system dark mode and preload palette
- apply unified color variables and sidebar styling
- document dark mode tasks and release notes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d25b4d20832eb0d319cca6cbadb5