### PR TITLE
feat: align titles with headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ _Only this section of the readme can be maintained using Russian language_
 - JavaScript only (no TypeScript).
 - No remote databases and no custom backend.
 - Demo data must come from local sources (in-memory, JSON, or localStorage).
+- Every page uses a single `<h1>` mirrored in the document title; non-home pages append " | ACPC".
 
 ## Tech and infrastructure
 - React + Vite (fast HMR).

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         }
       }
     </style>
-    <title>Vite + React</title>
+    <title>ACPC</title>
   </head>
   <body>
     <div id="root"></div>

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "generated": "2025-08-28T22:08:00+00:00",
+  "generated": "2025-08-29T00:00:00+00:00",
   "changes": [
     {
       "id": "2025-08-28T09:35:00+00:00-docs-docs",
@@ -89,16 +89,31 @@
         "en": "Implemented dark mode with consistent palette",
         "ru": "Реализован тёмный режим с согласованной палитрой"
       }
+    },
+    {
+      "id": "2025-08-29T00:00:00+00:00-feat-ui",
+      "timestamp": "2025-08-29T00:00:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Unified page titles with headings",
+        "ru": "Унифицированы тайтлы со страницами"
+      }
     }
   ],
   "daily": {
     "2025-08-28": {
       "en": "Release notes page shows English only; rules and style clarified; separated user and admin menus; added collapsible user sidebar; darkened sidebar and stabilized icons; implemented dark mode",
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
+    },
+    "2025-08-29": {
+      "en": "Aligned page titles with headings",
+      "ru": "Синхронизированы тайтлы с заголовками"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов"
   }
 }

--- a/src/pages/adminChartsPage.jsx
+++ b/src/pages/adminChartsPage.jsx
@@ -1,3 +1,9 @@
+import { useEffect } from 'react'
+
 export default function AdminChartsPage() {
-  return <h1>Admin Charts Page</h1>
+  const title = 'Admin Charts Page | ACPC'
+  useEffect(() => {
+    document.title = title
+  }, [title])
+  return <h1>{title}</h1>
 }

--- a/src/pages/adminPage.jsx
+++ b/src/pages/adminPage.jsx
@@ -1,3 +1,9 @@
+import { useEffect } from 'react'
+
 export default function AdminPage() {
-  return <h1>Admin Page</h1>
+  const title = 'Admin Page | ACPC'
+  useEffect(() => {
+    document.title = title
+  }, [title])
+  return <h1>{title}</h1>
 }

--- a/src/pages/mainPage.jsx
+++ b/src/pages/mainPage.jsx
@@ -1,3 +1,17 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+
 export default function MainPage() {
-  return <h1>Main Page</h1>
+  useEffect(() => {
+    document.title = 'ACPC'
+  }, [])
+  return (
+    <>
+      <h1>ACPC</h1>
+      <p>Welcome</p>
+      <p>
+        Go to <Link to="/admin">/admin</Link>
+      </p>
+    </>
+  )
 }

--- a/src/pages/releaseNotesPage.jsx
+++ b/src/pages/releaseNotesPage.jsx
@@ -1,6 +1,11 @@
+import { useEffect } from 'react'
 import releaseNotes from '../../release-notes.json'
 
 export default function ReleaseNotesPage() {
+  const title = 'Release Notes Page | ACPC'
+  useEffect(() => {
+    document.title = title
+  }, [title])
   const changes = [...releaseNotes.changes].sort(
     (a, b) => new Date(b.timestamp) - new Date(a.timestamp),
   )
@@ -13,6 +18,7 @@ export default function ReleaseNotesPage() {
   const dates = Object.keys(groups).sort((a, b) => new Date(b) - new Date(a))
   return (
     <div>
+      <h1>{title}</h1>
       {dates.map(date => (
         <div key={date}>
           <h2>{date}</h2>


### PR DESCRIPTION
## Summary
- unify document titles with page headers
- add welcome copy and admin link to the main page
- record title alignment in release notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d5ed6bf0832eb90db34ee4dd8ee0