### PR TITLE
fix: display release notes page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _Only this section of the readme can be maintained using Russian language_
   - [ ] 6.2 Создать страницу /release-notes где задействовать release-notes.json вверху страницы расположить sticky компонент для управления отображением релизов(HMR). В компоненте распложить:
   - - [x] 6.2.0 Реализовать базовый вывод релизов по времени.
   - - [ ] 6.2.1 Переключатель: релизы только по времени или релизы только по дням или кратчайшие релизы. Состояние переключателя при переключение сохранять в localstorage. (Создать /servises/localstorageHelper.jsx для лаконичного взаимодействия с localstorage.)
+  - - [x] 6.2.2 Исправить отображение содержимого на /release-notes.
 
 
 7. Recommendations from bot

--- a/release-notes.json
+++ b/release-notes.json
@@ -100,6 +100,17 @@
         "en": "Unified page titles with headings",
         "ru": "Унифицированы тайтлы со страницами"
       }
+    },
+    {
+      "id": "2025-08-29T00:30:00+00:00-fix-ui",
+      "timestamp": "2025-08-29T00:30:00+00:00",
+      "version": "0.0.0",
+      "type": "fix",
+      "scope": "ui",
+      "description": {
+        "en": "Fixed release notes layout showing content",
+        "ru": "Исправлено отображение release notes"
+      }
     }
   ],
   "daily": {
@@ -108,12 +119,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-      "en": "Aligned page titles with headings",
-      "ru": "Синхронизированы тайтлы с заголовками"
+      "en": "Aligned page titles with headings; fixed release notes layout",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes"
   }
 }

--- a/src/app/layout.css
+++ b/src/app/layout.css
@@ -1,0 +1,9 @@
+.layout {
+  display: flex;
+  width: 100%;
+}
+
+.layout > main {
+  flex: 1;
+  padding: 16px;
+}

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,14 +1,17 @@
 import { Outlet, useLocation } from 'react-router-dom'
 import BarLeftUser from './barLeftUser.jsx'
 import BarLeftAdmin from './barLeftAdmin.jsx'
+import './layout.css'
 
 export default function Layout() {
   const location = useLocation()
   const isAdminRoute = location.pathname.startsWith('/admin')
   return (
-    <>
+    <div className="layout">
       {isAdminRoute ? <BarLeftAdmin /> : <BarLeftUser />}
-      <Outlet />
-    </>
+      <main>
+        <Outlet />
+      </main>
+    </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -35,13 +35,17 @@
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
   color: var(--color-text);
   background-color: var(--color-bg);
   scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
+}
+
+#root {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
 }
 
 body::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- show release notes content by wrapping sidebar and main content in flex layout
- document release notes fix and update tracking docs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0d8ce5568832eaa196417f2a24169