### PR TITLE
feat: add login form variants page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, an admin dashboard, an admin charts screen, and a release notes page showing updates in English. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate admin menu. Pages live under `src/pages` and a shared layout under `src/app`.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, a UI login forms gallery, an admin dashboard, an admin charts screen, and a release notes page showing updates in English. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate admin menu. Pages live under `src/pages` and a shared layout under `src/app`.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -49,6 +49,9 @@ _Only this section of the readme can be maintained using Russian language_
 10. Тёмная тема
  - [x] 10.1 Распознавать prefers-color-scheme для автоматического переключения темы.
  - [x] 10.2 Применить тёмную палитру для сайдбара и интерфейса.
+
+11. UI каталог
+ - [x] 11.1 Создать страницу /ui-login-forms с 10 вариантами форм авторизации.
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "generated": "2025-08-29T00:00:00+00:00",
+  "generated": "2025-08-29T01:00:00+00:00",
   "changes": [
     {
       "id": "2025-08-28T09:35:00+00:00-docs-docs",
@@ -111,6 +111,17 @@
         "en": "Fixed release notes layout showing content",
         "ru": "Исправлено отображение release notes"
       }
+    },
+    {
+      "id": "2025-08-29T01:00:00+00:00-feat-ui",
+      "timestamp": "2025-08-29T01:00:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Added login form variants page",
+        "ru": "Добавлена страница вариантов форм входа"
+      }
     }
   ],
   "daily": {
@@ -119,12 +130,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-      "en": "Aligned page titles with headings; fixed release notes layout",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes"
+      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа"
   }
 }

--- a/src/app/barLeftUser.jsx
+++ b/src/app/barLeftUser.jsx
@@ -59,6 +59,7 @@ export default function BarLeftUser() {
           <Link to="/admin">/admin</Link>
           <Link to="/admin/charts">/admin/charts</Link>
           <Link to="/release-notes">/release-notes</Link>
+          <Link to="/ui-login-forms">/ui-login-forms</Link>
         </nav>
       )}
     </aside>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import MainPage from './pages/mainPage.jsx'
 import AdminPage from './pages/adminPage.jsx'
 import AdminChartsPage from './pages/adminChartsPage.jsx'
 import ReleaseNotesPage from './pages/releaseNotesPage.jsx'
+import UiLoginFormsPage from './pages/uiLoginFormsPage.jsx'
 
 const router = createBrowserRouter([
   {
@@ -17,6 +18,7 @@ const router = createBrowserRouter([
       { path: 'admin', element: <AdminPage /> },
       { path: 'admin/charts', element: <AdminChartsPage /> },
       { path: 'release-notes', element: <ReleaseNotesPage /> },
+      { path: 'ui-login-forms', element: <UiLoginFormsPage /> },
     ],
   },
 ])

--- a/src/pages/uiLoginFormsPage.css
+++ b/src/pages/uiLoginFormsPage.css
@@ -1,0 +1,66 @@
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 240px;
+}
+
+.login-form input,
+.login-form button {
+  padding: 4px 8px;
+}
+
+.variant-2 {
+  align-items: center;
+}
+
+.variant-3 {
+  border: 1px solid #ccc;
+  padding: 8px;
+}
+
+.variant-4 {
+  background: #f0f0f0;
+  padding: 8px;
+}
+
+.variant-5 {
+  gap: 16px;
+}
+
+.variant-6 {
+  flex-direction: row;
+  align-items: center;
+}
+
+.variant-6 input {
+  flex: 1;
+}
+
+.variant-7 {
+  background: #222;
+  padding: 8px;
+}
+
+.variant-7 input,
+.variant-7 button {
+  background: #333;
+  color: #fff;
+  border: none;
+}
+
+.variant-8 input {
+  border: none;
+  border-bottom: 1px solid #000;
+}
+
+.variant-9 input,
+.variant-9 button {
+  border-radius: 8px;
+}
+
+.variant-10 {
+  border: 1px dashed #666;
+  padding: 8px;
+  background: #fafafa;
+}

--- a/src/pages/uiLoginFormsPage.jsx
+++ b/src/pages/uiLoginFormsPage.jsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import './uiLoginFormsPage.css'
+
+export default function UiLoginFormsPage() {
+  const title = 'Login form variants | ACPC'
+  useEffect(() => {
+    document.title = title
+  }, [title])
+
+  const variants = Array.from({ length: 10 }, (_, i) => i + 1)
+
+  return (
+    <div>
+      <h1>Login form variants</h1>
+      {variants.map((num, idx) => (
+        <div key={num}>
+          <h2>{num}</h2>
+          <form className={`login-form variant-${num}`}>
+            <input type="text" placeholder="Login" />
+            <input type="password" placeholder="Password" />
+            <button type="button">Login</button>
+          </form>
+          {idx < variants.length - 1 && <hr />}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add /ui-login-forms page with 10 login form designs
- link new page from router and sidebar
- document page in readme and release notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `jq . release-notes.json`

------
https://chatgpt.com/codex/tasks/task_e_68b0dbde575c832ea7ae2f0d1ff4ceeb