### PR TITLE
feat: add admin sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, a UI login forms gallery, an admin dashboard, an admin charts screen, and a release notes page showing updates in English. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate admin menu. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page, a UI login forms gallery, an admin dashboard, an admin charts screen, and a release notes page showing updates in English. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -41,7 +41,8 @@ _Only this section of the readme can be maintained using Russian language_
  - [x] 8.1 Создать компонент barLeftUser со ссылками на все страницы.
   - [x] 8.2 Создать компонент barLeftAdmin (пустой).
   - [x] 8.3 Подключить barLeftUser на всех страницах кроме /admin/*, barLeftAdmin на /admin/*.
-  - [x] 8.4 Уточнить порядок и расстояния иконок в сайдбаре пользователя.
+    - [x] 8.4 Уточнить порядок и расстояния иконок в сайдбаре пользователя.
+   - [x] 8.5 Реализовать функциональность barLeftAdmin.
 
 9. Документация
  - [x] 9.1 Перечислить все используемые библиотеки в readme.
@@ -112,6 +113,8 @@ _Only this section of the readme can be maintained using Russian language_
 ## Code duplication log
 - `src/user/app/layout.jsx` duplicated in `src/admin/app/layout.jsx`
 - `src/user/app/layout.css` duplicated in `src/admin/app/layout.css`
+- `src/user/app/barLeftUser.jsx` duplicated in `src/admin/app/barLeftAdmin.jsx`
+- `src/user/app/barLeftUser.css` duplicated in `src/admin/app/barLeftAdmin.css`
 
 ## Release notes
 - File `release-notes.json` follows [release-notes-howto.md](release-notes-howto.md).

--- a/release-notes.json
+++ b/release-notes.json
@@ -134,6 +134,18 @@
         "ru": "Задокументировано разделение кода на пользователя и админа"
       }
     }
+    ,
+    {
+      "id": "2025-08-29T03:30:00+00:00-feat-ui",
+      "timestamp": "2025-08-29T03:30:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Added collapsible admin sidebar",
+        "ru": "Добавлен сворачиваемый сайдбар админа"
+      }
+    }
   ],
   "daily": {
     "2025-08-28": {
@@ -141,12 +153,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа"
+      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа"
   }
 }

--- a/src/admin/app/barLeftAdmin.css
+++ b/src/admin/app/barLeftAdmin.css
@@ -1,0 +1,54 @@
+.sidebar-left {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 250px;
+  transition: width 0.3s ease;
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border-right: 1px solid var(--color-border);
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
+}
+.sidebar-left::-webkit-scrollbar {
+  width: 8px;
+}
+.sidebar-left::-webkit-scrollbar-thumb {
+  background-color: var(--color-scrollbar-thumb);
+}
+.sidebar-left::-webkit-scrollbar-track {
+  background-color: var(--color-scrollbar-track);
+}
+.sidebar-left.collapsed {
+  width: 32px;
+  padding: 0;
+}
+.sidebar-header {
+  display: flex;
+  flex-direction: row;
+  gap: 0;
+}
+.icon-button {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  color: var(--color-text);
+}
+.icon-button:hover {
+  background-color: var(--color-hover);
+}
+.sidebar-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px;
+  color: var(--color-text);
+}
+.sidebar-left.collapsed .sidebar-content {
+  display: none;
+}

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -1,3 +1,64 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Sidebar, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
+import './barLeftAdmin.css'
+
 export default function BarLeftAdmin() {
-  return <nav></nav>
+  const [collapsed, setCollapsed] = useState(true)
+  const [hovered, setHovered] = useState(false)
+
+  useEffect(() => {
+    const saved = localStorage.getItem('barLeftAdminCollapsed')
+    if (saved !== null) {
+      setCollapsed(saved === 'true')
+    }
+  }, [])
+
+  useEffect(() => {
+    function handleBlur() {
+      if (collapsed) setHovered(false)
+    }
+    window.addEventListener('blur', handleBlur)
+    return () => window.removeEventListener('blur', handleBlur)
+  }, [collapsed])
+
+  const isCollapsed = collapsed && !hovered
+
+  const toggle = () => {
+    const next = !collapsed
+    setCollapsed(next)
+    localStorage.setItem('barLeftAdminCollapsed', String(next))
+  }
+
+  const onIconEnter = () => {
+    if (collapsed) setHovered(true)
+  }
+
+  const onMouseLeave = () => {
+    if (collapsed) setHovered(false)
+  }
+
+  return (
+    <aside className={`sidebar-left ${isCollapsed ? 'collapsed' : ''}`} onMouseLeave={onMouseLeave}>
+      <div className="sidebar-header">
+        <div className="icon-button" onMouseEnter={onIconEnter} onClick={toggle}>
+          <Sidebar size={16} />
+        </div>
+        {!isCollapsed && (
+          <>
+            <div className="icon-button"><Columns size={16} /></div>
+            <div className="icon-button"><Calendar size={16} /></div>
+            <div className="icon-button"><CheckCircle size={16} /></div>
+            <div className="icon-button"><Cloud size={16} /></div>
+          </>
+        )}
+      </div>
+      {!isCollapsed && (
+        <nav className="sidebar-content">
+          <Link to="/admin">/admin</Link>
+          <Link to="/admin/charts">/admin/charts</Link>
+        </nav>
+      )}
+    </aside>
+  )
 }

--- a/src/admin/pages/adminChartsPage.jsx
+++ b/src/admin/pages/adminChartsPage.jsx
@@ -1,9 +1,14 @@
 import { useEffect } from 'react'
 
 export default function AdminChartsPage() {
-  const title = 'Admin Charts Page | ACPC'
+  const title = 'Admin Charts Page'
+  const fullTitle = `${title} | Admin | ACPC`
   useEffect(() => {
-    document.title = title
-  }, [title])
-  return <h1>{title}</h1>
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+    </div>
+  )
 }

--- a/src/admin/pages/adminPage.jsx
+++ b/src/admin/pages/adminPage.jsx
@@ -1,9 +1,14 @@
 import { useEffect } from 'react'
 
 export default function AdminPage() {
-  const title = 'Admin Page | ACPC'
+  const title = 'Admin Page'
+  const fullTitle = `${title} | Admin | ACPC`
   useEffect(() => {
-    document.title = title
-  }, [title])
-  return <h1>{title}</h1>
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- implement collapsible admin sidebar mirroring user sidebar
- update admin page titles to include Admin label
- document admin sidebar and code duplication

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0e654cba8832eb5a6619cbeb6ce1b