### PR TITLE
feat: update home page icon and greeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ _Only this section of the readme can be maintained using Russian language_
 12. Code organization
  - [x] 12.1 Разделить код на /src/user и /src/admin с отдельными app и pages.
 
+13. Главная страница
+ - [x] 13.1 Добавить иконку перед названием
+ - [x] 13.2 Заменить текст приветствия
+ - [x] 13.3 Обновить ссылку /admin
+
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.
 2. Maintain a hierarchical task list with consistent numbering.

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "generated": "2025-08-29T04:00:00+00:00",
+  "generated": "2025-08-29T06:30:00+00:00",
   "changes": [
     {
       "id": "2025-08-28T09:35:00+00:00-docs-docs",
@@ -166,6 +166,17 @@
         "en": "Added tooltips and home icon links to sidebars",
         "ru": "Добавлены подсказки и ссылка-домик в сайдбары"
       }
+    },
+    {
+      "id": "2025-08-29T06:30:00+00:00-feat-ui",
+      "timestamp": "2025-08-29T06:30:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Displayed site icon and refreshed home page texts",
+        "ru": "Показана иконка сайта и обновлены тексты главной"
+      }
     }
   ],
   "daily": {
@@ -174,12 +185,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары"
+      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной"
   }
 }

--- a/src/user/pages/mainPage.jsx
+++ b/src/user/pages/mainPage.jsx
@@ -7,10 +7,17 @@ export default function MainPage() {
   }, [])
   return (
     <>
-      <h1>ACPC</h1>
-      <p>Welcome</p>
+      <h1>
+        <img
+          src="/icon.svg"
+          alt="ACPC icon"
+          style={{ height: '1em', verticalAlign: 'middle', marginRight: '0.2em' }}
+        />
+        ACPC
+      </h1>
+      <p>Welcome to site with AdminCP with Charts!</p>
       <p>
-        Go to <Link to="/admin">/admin</Link>
+        Go to <Link to="/admin">/admin</Link> to see.
       </p>
     </>
   )


### PR DESCRIPTION
## Summary
- show site icon before the ACPC title on the home page
- expand home page greeting and clarify admin link
- log the change in release notes and task list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `jq . release-notes.json`


------
https://chatgpt.com/codex/tasks/task_e_68b0f1d53574832e998f90695b300d00