### PR TITLE
feat(admin): add hashtag UI variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can access a dashboard, a charts screen, and a UI page with login form variants. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can access a dashboard, a charts screen, and a UI page with login form and hashtag variants. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -54,6 +54,7 @@ _Only this section of the readme can be maintained using Russian language_
 
 11. UI каталог
  - [x] 11.1 Создать страницу /admin/ui с 10 вариантами форм авторизации.
+ - [x] 11.2 Добавить 10 вариантов отображения хэштегов.
 
 12. Code organization
  - [x] 12.1 Разделить код на /src/user и /src/admin с отдельными app и pages.

--- a/release-notes.json
+++ b/release-notes.json
@@ -177,6 +177,17 @@
         "en": "Displayed site icon and refreshed home page texts",
         "ru": "Показана иконка сайта и обновлены тексты главной"
       }
+    },
+    {
+      "id": "2025-08-29T07:00:00+00:00-feat-ui",
+      "timestamp": "2025-08-29T07:00:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Added hashtag display variants on admin UI",
+        "ru": "Добавлены варианты отображения хэштегов в админском UI"
+      }
     }
   ],
   "daily": {
@@ -185,12 +196,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной"
+      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов"
   }
 }

--- a/src/admin/pages/adminUiPage.css
+++ b/src/admin/pages/adminUiPage.css
@@ -64,3 +64,50 @@
   padding: 8px;
   background: #fafafa;
 }
+
+.tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.tags-variant-2 {
+  justify-content: center;
+}
+
+.tags-variant-3 span {
+  font-weight: bold;
+}
+
+.tags-variant-4 span {
+  color: #007bff;
+}
+
+.tags-variant-5 span {
+  text-decoration: underline;
+}
+
+.tags-variant-6 span {
+  background: #eee;
+  padding: 2px 6px;
+}
+
+.tags-variant-7 span {
+  background: #222;
+  color: #fff;
+  padding: 2px 6px;
+}
+
+.tags-variant-8 span {
+  border: 1px solid #666;
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.tags-variant-9 {
+  flex-direction: column;
+}
+
+.tags-variant-10 span {
+  font-size: 1.2em;
+}

--- a/src/admin/pages/adminUiPage.jsx
+++ b/src/admin/pages/adminUiPage.jsx
@@ -7,21 +7,37 @@ export default function AdminUiPage() {
     document.title = title
   }, [title])
 
-  const variants = Array.from({ length: 10 }, (_, i) => i + 1)
+  const loginVariants = Array.from({ length: 10 }, (_, i) => i + 1)
+  const tagVariants = Array.from({ length: 10 }, (_, i) => i + 1)
+  const tags = ['#alpha', '#beta', '#gamma']
 
   return (
     <div>
       <h1>UI</h1>
+
       <h2>Login form variants</h2>
-      {variants.map((num, idx) => (
-        <div key={num}>
+      {loginVariants.map((num, idx) => (
+        <div key={`login-${num}`}>
           <h3>{num}</h3>
           <form className={`login-form variant-${num}`}>
             <input type="text" placeholder="Login" />
             <input type="password" placeholder="Password" />
             <button type="button">Login</button>
           </form>
-          {idx < variants.length - 1 && <hr />}
+          {idx < loginVariants.length - 1 && <hr />}
+        </div>
+      ))}
+
+      <h2>Hashtag variants</h2>
+      {tagVariants.map((num, idx) => (
+        <div key={`tags-${num}`}>
+          <h3>{num}</h3>
+          <div className={`tags tags-variant-${num}`}>
+            {tags.map(tag => (
+              <span key={tag}>{tag}</span>
+            ))}
+          </div>
+          {idx < tagVariants.length - 1 && <hr />}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- showcase 10 hashtag display styles on /admin/ui
- document hashtag showcase in README and release notes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0f2cbc5c0832eaef9e0beda4d26cc