### PR TITLE
feat: expand admin UI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can access a dashboard, a charts screen, and a UI page with twenty login form variants and twenty hashtag variants. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -58,6 +58,10 @@ _Only this section of the readme can be maintained using Russian language_
  - [x] 11.2 Добавить 10 вариантов отображения хэштегов.
  - [x] 11.3 Добавить ещё 10 вариантов форм авторизации.
  - [x] 11.4 Добавить ещё 10 вариантов отображения хэштегов.
+
+ - [x] 11.5 Добавить пометку "current choice" для выбранных вариантов.
+ - [x] 11.6 Добавить ещё 10 вариантов форм авторизации.
+ - [x] 11.7 Добавить ещё 10 вариантов отображения хэштегов.
 
 12. Code organization
  - [x] 12.1 Разделить код на /src/user и /src/admin с отдельными app и pages.

--- a/release-notes.json
+++ b/release-notes.json
@@ -199,6 +199,17 @@
         "en": "Expanded login and hashtag variants on admin UI",
         "ru": "Расширены варианты форм входа и хэштегов в админском UI"
       }
+    },
+    {
+      "id": "2025-08-29T09:00:00+00:00-feat-ui",
+      "timestamp": "2025-08-29T09:00:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Marked current UI choices and added ten more form and hashtag variants",
+        "ru": "Отмечены текущие варианты UI и добавлены ещё десять форм и хэштегов"
+      }
     }
   ],
   "daily": {
@@ -207,12 +218,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов"
+      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати"
   }
 }

--- a/src/admin/pages/adminUiPage.css
+++ b/src/admin/pages/adminUiPage.css
@@ -124,6 +124,49 @@
   border: none;
 }
 
+.variant-21 {
+  align-items: flex-end;
+}
+
+.variant-22 input {
+  border: 2px solid red;
+}
+
+.variant-23 {
+  background: linear-gradient(#eef, #cce);
+  padding: 8px;
+}
+
+.variant-24 button {
+  width: 100%;
+}
+
+.variant-25 {
+  gap: 20px;
+}
+
+.variant-26 input {
+  font-style: italic;
+}
+
+.variant-27 {
+  border-top: 4px solid #000;
+  padding-top: 8px;
+}
+
+.variant-28 {
+  display: grid;
+  gap: 8px;
+}
+
+.variant-29 input {
+  background: #f9f9f9;
+}
+
+.variant-30 button {
+  border-radius: 9999px;
+}
+
 .tags {
   display: flex;
   gap: 4px;
@@ -217,4 +260,49 @@
   color: #fff;
   text-shadow: 1px 1px 0 #333;
   padding: 2px 6px;
+}
+
+.tags-variant-21 span {
+  border: 1px solid #000;
+  padding: 2px 6px;
+}
+
+.tags-variant-22 {
+  gap: 8px;
+}
+
+.tags-variant-23 span {
+  background: #eef;
+}
+
+.tags-variant-24 span {
+  background: #cfc;
+  color: #000;
+}
+
+.tags-variant-25 span {
+  border: 1px solid #666;
+  border-radius: 9999px;
+  padding: 2px 8px;
+}
+
+.tags-variant-26 {
+  flex-direction: row-reverse;
+}
+
+.tags-variant-27 span {
+  font-variant: small-caps;
+}
+
+.tags-variant-28 span {
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+}
+
+.tags-variant-29 span {
+  background: #007bff;
+  color: #fff;
+}
+
+.tags-variant-30 {
+  justify-content: flex-end;
 }

--- a/src/admin/pages/adminUiPage.jsx
+++ b/src/admin/pages/adminUiPage.jsx
@@ -7,8 +7,10 @@ export default function AdminUiPage() {
     document.title = title
   }, [title])
 
-  const loginVariants = Array.from({ length: 20 }, (_, i) => i + 1)
-  const tagVariants = Array.from({ length: 20 }, (_, i) => i + 1)
+  const loginVariants = Array.from({ length: 30 }, (_, i) => i + 1)
+  const tagVariants = Array.from({ length: 30 }, (_, i) => i + 1)
+  const loginChoice = 3
+  const tagChoice = 20
   const tags = ['#alpha', '#beta', '#gamma']
 
   return (
@@ -18,7 +20,10 @@ export default function AdminUiPage() {
       <h2>Login form variants</h2>
       {loginVariants.map((num, idx) => (
         <div key={`login-${num}`}>
-          <h3>{num}</h3>
+          <h3>
+            {num}
+            {num === loginChoice ? ' current choice' : ''}
+          </h3>
           <form className={`login-form variant-${num}`}>
             <input type="text" placeholder="Login" />
             <input type="password" placeholder="Password" />
@@ -31,7 +36,10 @@ export default function AdminUiPage() {
       <h2>Hashtag variants</h2>
       {tagVariants.map((num, idx) => (
         <div key={`tags-${num}`}>
-          <h3>{num}</h3>
+          <h3>
+            {num}
+            {num === tagChoice ? ' current choice' : ''}
+          </h3>
           <div className={`tags tags-variant-${num}`}>
             {tags.map(tag => (
               <span key={tag}>{tag}</span>


### PR DESCRIPTION
## Summary
- mark chosen login and hashtag variants with "current choice"
- add ten more login form and hashtag styles (30 total each)
- document changes in readme and release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0fbc4864c832ebde6d158fad414d8