### PR TITLE
feat(auth): add admin logout and auth enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -15,9 +15,10 @@ _Only this section of the readme can be maintained using Russian language_
  
 2. Авторизация
   - [x] 2.1 Создать страницу /admin/login .
-  - [x] 2.2 Использовать переменные окружения для хранения данных авторизации администратора.
+ - [x] 2.2 Использовать переменные окружения для хранения данных авторизации администратора.
   - [x] 2.3 Перенаправление на страницу /admin при успешном вводе логина и пароля на /admin/login .
-  - [ ] 2.4 Проверять авторизацию на всех страницах /admin/*. Если нет авторизации, то редирект на /admin/login .
+  - [x] 2.4 Проверять авторизацию на всех страницах /admin/*. Если нет авторизации, то редирект на /admin/login .
+  - [x] 2.5 Добавить страницу /admin/logout, сообщение об успешной авторизации и ссылку на выход.
 
 3. Графики
   - [ ] 3.1 Создать /admin/dev/charts . Создать /admin/dev/ , которая редиректит на /admin/dev/charts .

--- a/release-notes.json
+++ b/release-notes.json
@@ -221,6 +221,17 @@
         "en": "Added admin login page and set login form variant 30 as current choice",
         "ru": "Добавлена страница входа админа и выбран вариант формы 30"
       }
+    },
+    {
+      "id": "2025-08-29T11:00:00+00:00-feat-auth",
+      "timestamp": "2025-08-29T11:00:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "auth",
+      "description": {
+        "en": "Added admin logout page and enforced auth redirects",
+        "ru": "Добавлена страница выхода админа и проверка авторизации на страницах"
+      }
     }
   ],
   "daily": {
@@ -229,12 +240,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty; added admin login page",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати; добавлена страница входа админа"
+      "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty; added admin login page; added admin logout page and auth checks",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации на страницах"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty; added admin login page",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати; добавлена страница входа админа"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty; added admin login page; admin logout page and auth checks",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации"
   }
 }

--- a/src/admin/app/auth.js
+++ b/src/admin/app/auth.js
@@ -1,0 +1,8 @@
+export function isAdminAuth() {
+  return localStorage.getItem('adminAuth') === 'true'
+}
+
+export function logoutAdmin() {
+  localStorage.removeItem('adminAuth')
+  localStorage.removeItem('adminLogin')
+}

--- a/src/admin/app/authMessage.jsx
+++ b/src/admin/app/authMessage.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom'
+import { isAdminAuth } from './auth.js'
+
+export default function AuthMessage() {
+  const login = import.meta.env.VITE_ADMIN_LOGIN
+  if (!isAdminAuth()) return null
+  return (
+    <p>
+      {login} успешно авторизован, <Link to="/admin/logout">выход</Link>
+    </p>
+  )
+}

--- a/src/admin/app/barLeftAdmin.css
+++ b/src/admin/app/barLeftAdmin.css
@@ -42,6 +42,10 @@
 .icon-button:hover {
   background-color: var(--color-hover);
 }
+.icon-button.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
 .sidebar-content {
   display: flex;
   flex-direction: column;

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -3,16 +3,20 @@ import { Link } from 'react-router-dom'
 import { Sidebar, Home, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
 import './barLeftAdmin.css'
 
-export default function BarLeftAdmin() {
+export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = false }) {
   const [collapsed, setCollapsed] = useState(true)
   const [hovered, setHovered] = useState(false)
 
   useEffect(() => {
+    if (forceCollapsed) {
+      setCollapsed(true)
+      return
+    }
     const saved = localStorage.getItem('barLeftAdminCollapsed')
     if (saved !== null) {
       setCollapsed(saved === 'true')
     }
-  }, [])
+  }, [forceCollapsed])
 
   useEffect(() => {
     function handleBlur() {
@@ -25,13 +29,14 @@ export default function BarLeftAdmin() {
   const isCollapsed = collapsed && !hovered
 
   const toggle = () => {
+    if (disableToggle || forceCollapsed) return
     const next = !collapsed
     setCollapsed(next)
     localStorage.setItem('barLeftAdminCollapsed', String(next))
   }
 
   const onIconEnter = () => {
-    if (collapsed) setHovered(true)
+    if (collapsed && !disableToggle && !forceCollapsed) setHovered(true)
   }
 
   const onMouseLeave = () => {
@@ -42,9 +47,9 @@ export default function BarLeftAdmin() {
     <aside className={`sidebar-left ${isCollapsed ? 'collapsed' : ''}`} onMouseLeave={onMouseLeave}>
       <div className="sidebar-header">
         <div
-          className="icon-button"
-          onMouseEnter={onIconEnter}
-          onClick={toggle}
+          className={`icon-button${disableToggle ? ' disabled' : ''}`}
+          onMouseEnter={disableToggle ? undefined : onIconEnter}
+          onClick={disableToggle ? undefined : toggle}
           title="Toggle sidebar"
         >
           <Sidebar size={16} />
@@ -74,6 +79,7 @@ export default function BarLeftAdmin() {
           <Link to="/admin">/admin</Link>
           <Link to="/admin/charts">/admin/charts</Link>
           <Link to="/admin/ui">/admin/ui</Link>
+          <Link to="/admin/logout">/admin/logout</Link>
         </nav>
       )}
     </aside>

--- a/src/admin/app/layout.jsx
+++ b/src/admin/app/layout.jsx
@@ -1,11 +1,23 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { useEffect } from 'react'
 import BarLeftAdmin from './barLeftAdmin.jsx'
+import { isAdminAuth } from './auth.js'
 import './layout.css'
 
 export default function Layout() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const isLogin = location.pathname === '/admin/login'
+
+  useEffect(() => {
+    if (!isLogin && !isAdminAuth()) {
+      navigate('/admin/login', { replace: true })
+    }
+  }, [isLogin, navigate, location])
+
   return (
     <div className="layout">
-      <BarLeftAdmin />
+      <BarLeftAdmin forceCollapsed={isLogin} disableToggle={isLogin} />
       <main>
         <Outlet />
       </main>

--- a/src/admin/pages/adminChartsPage.jsx
+++ b/src/admin/pages/adminChartsPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
 
 export default function AdminChartsPage() {
   const title = 'Admin Charts Page'
@@ -9,6 +10,7 @@ export default function AdminChartsPage() {
   return (
     <div>
       <h1>{fullTitle}</h1>
+      <AuthMessage />
     </div>
   )
 }

--- a/src/admin/pages/adminLoginPage.jsx
+++ b/src/admin/pages/adminLoginPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import AuthMessage from '../app/authMessage.jsx'
 import './adminUiPage.css'
 
 export default function AdminLoginPage() {
@@ -19,6 +20,8 @@ export default function AdminLoginPage() {
     const envLogin = import.meta.env.VITE_ADMIN_LOGIN
     const envPassword = import.meta.env.VITE_ADMIN_PASSWORD
     if (username === envLogin && password === envPassword) {
+      localStorage.setItem('adminAuth', 'true')
+      localStorage.setItem('adminLogin', username)
       navigate('/admin')
     } else {
       setError('Invalid username or password')
@@ -28,30 +31,33 @@ export default function AdminLoginPage() {
   const disabled = !username || !password
 
   return (
-    <div>
-      <h1>Admin Login</h1>
-      <form className="login-form variant-30" onSubmit={handleSubmit}>
-        <input
-          type="text"
-          placeholder="Login"
-          value={username}
-          onChange={e => {
-            setUsername(e.target.value)
-            if (error) setError('')
-          }}
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={e => {
-            setPassword(e.target.value)
-            if (error) setError('')
-          }}
-        />
-        <button type="submit" disabled={disabled}>Login</button>
-      </form>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
+    <div className="login-page">
+      <div>
+        <h1>Admin Login</h1>
+        <AuthMessage />
+        <form className="login-form variant-30" onSubmit={handleSubmit}>
+          <input
+            type="text"
+            placeholder="Login"
+            value={username}
+            onChange={e => {
+              setUsername(e.target.value)
+              if (error) setError('')
+            }}
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={e => {
+              setPassword(e.target.value)
+              if (error) setError('')
+            }}
+          />
+          <button type="submit" disabled={disabled}>Login</button>
+        </form>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+      </div>
     </div>
   )
 }

--- a/src/admin/pages/adminLogoutPage.jsx
+++ b/src/admin/pages/adminLogoutPage.jsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import AuthMessage from '../app/authMessage.jsx'
+import { isAdminAuth, logoutAdmin } from '../app/auth.js'
+
+export default function AdminLogoutPage() {
+  const navigate = useNavigate()
+  useEffect(() => {
+    if (isAdminAuth()) {
+      logoutAdmin()
+    }
+    navigate('/admin/login', { replace: true })
+  }, [navigate])
+
+  return (
+    <div>
+      <h1>Logout</h1>
+      <AuthMessage />
+    </div>
+  )
+}

--- a/src/admin/pages/adminPage.jsx
+++ b/src/admin/pages/adminPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
 
 export default function AdminPage() {
   const title = 'Admin Page'
@@ -9,6 +10,7 @@ export default function AdminPage() {
   return (
     <div>
       <h1>{fullTitle}</h1>
+      <AuthMessage />
     </div>
   )
 }

--- a/src/admin/pages/adminUiPage.css
+++ b/src/admin/pages/adminUiPage.css
@@ -5,6 +5,13 @@
   max-width: 240px;
 }
 
+.login-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 32px);
+}
+
 .login-form input,
 .login-form button {
   padding: 4px 8px;

--- a/src/admin/pages/adminUiPage.jsx
+++ b/src/admin/pages/adminUiPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
 import './adminUiPage.css'
 
 export default function AdminUiPage() {
@@ -16,6 +17,7 @@ export default function AdminUiPage() {
   return (
     <div>
       <h1>UI</h1>
+      <AuthMessage />
 
       <h2>Login form variants</h2>
       {loginVariants.map((num, idx) => (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,9 +10,9 @@ import AdminPage from './admin/pages/adminPage.jsx'
 import AdminChartsPage from './admin/pages/adminChartsPage.jsx'
 import AdminUiPage from './admin/pages/adminUiPage.jsx'
 import AdminLoginPage from './admin/pages/adminLoginPage.jsx'
+import AdminLogoutPage from './admin/pages/adminLogoutPage.jsx'
 
 const router = createBrowserRouter([
-  { path: '/admin/login', element: <AdminLoginPage /> },
   {
     path: '/',
     element: <UserLayout />,
@@ -25,6 +25,8 @@ const router = createBrowserRouter([
     path: '/admin',
     element: <AdminLayout />,
     children: [
+      { path: 'login', element: <AdminLoginPage /> },
+      { path: 'logout', element: <AdminLogoutPage /> },
       { index: true, element: <AdminPage /> },
       { path: 'charts', element: <AdminChartsPage /> },
       { path: 'ui', element: <AdminUiPage /> },


### PR DESCRIPTION
## Summary
- enforce admin auth on all /admin routes with redirect to login
- add logout page and sidebar link
- show logged-in message with logout link on admin pages; center login form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b102b23888832e88de08b36a76cde6