### PR TITLE
feat: redirect admin to intended page after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP+Charts now
 Current version: 0.0.0
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
+ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -19,6 +19,7 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 2.3 Перенаправление на страницу /admin при успешном вводе логина и пароля на /admin/login .
   - [x] 2.4 Проверять авторизацию на всех страницах /admin/*. Если нет авторизации, то редирект на /admin/login .
   - [x] 2.5 Добавить страницу /admin/logout, сообщение об успешной авторизации и ссылку на выход.
+  - [x] 2.6 Возвращать на запрошенную страницу /admin/* после успешной авторизации.
 
 3. Графики
   - [ ] 3.1 Создать /admin/dev/charts . Создать /admin/dev/ , которая редиректит на /admin/dev/charts .

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "generated": "2025-08-29T12:00:00+00:00",
+  "generated": "2025-08-29T12:30:00+00:00",
   "changes": [
     {
       "id": "2025-08-28T09:35:00+00:00-docs-docs",
@@ -243,6 +243,17 @@
         "en": "Translated admin auth message to English",
         "ru": "Сообщение авторизации админа переведено на английский"
       }
+    },
+    {
+      "id": "2025-08-29T12:30:00+00:00-feat-auth",
+      "timestamp": "2025-08-29T12:30:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "auth",
+      "description": {
+        "en": "Redirected admins to requested page after login",
+        "ru": "После входа админов перенаправляет на запрошенную страницу"
+      }
     }
   ],
   "daily": {
@@ -251,12 +262,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-        "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty; added admin login page; added admin logout page and auth checks; translated admin auth message to English",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации на страницах; сообщение авторизации админа переведено на английский"
+        "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty; added admin login page; added admin logout page and auth checks; translated admin auth message to English; redirected admins to requested page after login",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации на страницах; сообщение авторизации админа переведено на английский; после входа админов перенаправляет на запрошенную страницу"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty; added admin login page; admin logout page and auth checks; admin auth message in English",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации; сообщение авторизации админа на английском"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty; added admin login page; admin logout page and auth checks; login redirect to requested admin page; admin auth message in English",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации; редирект на запрошенную страницу после входа; сообщение авторизации админа на английском"
   }
 }

--- a/src/admin/app/auth.js
+++ b/src/admin/app/auth.js
@@ -5,4 +5,5 @@ export function isAdminAuth() {
 export function logoutAdmin() {
   localStorage.removeItem('adminAuth')
   localStorage.removeItem('adminLogin')
+  localStorage.removeItem('adminPostLoginRedirect')
 }

--- a/src/admin/app/layout.jsx
+++ b/src/admin/app/layout.jsx
@@ -11,6 +11,7 @@ export default function Layout() {
 
   useEffect(() => {
     if (!isLogin && !isAdminAuth()) {
+      localStorage.setItem('adminPostLoginRedirect', location.pathname + location.search)
       navigate('/admin/login', { replace: true })
     }
   }, [isLogin, navigate, location])

--- a/src/admin/pages/adminLoginPage.jsx
+++ b/src/admin/pages/adminLoginPage.jsx
@@ -22,7 +22,9 @@ export default function AdminLoginPage() {
     if (username === envLogin && password === envPassword) {
       localStorage.setItem('adminAuth', 'true')
       localStorage.setItem('adminLogin', username)
-      navigate('/admin')
+      const redirect = localStorage.getItem('adminPostLoginRedirect') || '/admin'
+      localStorage.removeItem('adminPostLoginRedirect')
+      navigate(redirect)
     } else {
       setError('Invalid username or password')
     }


### PR DESCRIPTION
## Summary
- store original admin path when redirecting to login
- return admins to their requested page after login and clear redirect on logout
- document behavior and update release notes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b10d92c9e8832ea185ba183cea85ca