### PR TITLE
feat: list admin subpages via component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Current version: 0.0.0
 
 ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
+Every admin page lists its subpages at the bottom via a dedicated component.
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -23,7 +24,7 @@ _Only this section of the readme can be maintained using Russian language_
 
 3. Графики
   - [ ] 3.1 Создать /admin/dev/charts . Создать /admin/dev/ , которая редиректит на /admin/dev/charts .
-  - [ ] 3.2 Добавить правило для ботов в readme, что если есть вложенные страницы, то использовать специальный компонент для вывода подстраниц согласно схеме роутинга. Хранить этот компоент в отдельном файле. 
+  - [x] 3.2 Добавить правило для ботов в readme, что если есть вложенные страницы, то использовать специальный компонент для вывода подстраниц согласно схеме роутинга. Хранить этот компоент в отдельном файле.
   - [ ] 3.2.1 Создать страницу /admin/dev/charts/recharts и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Recharts. После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
   - [ ] 3.2.2 Создать страницу /admin/dev/charts/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
 
@@ -94,6 +95,7 @@ _Only this section of the readme can be maintained using Russian language_
 12. If there is no indication what language the page should be in, use English.
 13. Update `release-notes.json` for every user-facing change according to `release-notes-howto.md`.
 14. Keep user and admin code separated in `/src/user` and `/src/admin`, each containing its own `app` and `pages` directories. Allow duplication between them but record every instance in the "Code duplication log" section.
+15. When a page has nested routes, list its subpages at the end using the dedicated `SubPages` component stored in its own file.
  
 # Project details
 

--- a/release-notes.json
+++ b/release-notes.json
@@ -254,6 +254,17 @@
         "en": "Redirected admins to requested page after login",
         "ru": "После входа админов перенаправляет на запрошенную страницу"
       }
+    },
+    {
+      "id": "2025-08-29T13:00:00+00:00-feat-ui",
+      "timestamp": "2025-08-29T13:00:00+00:00",
+      "version": "0.0.0",
+      "type": "feat",
+      "scope": "ui",
+      "description": {
+        "en": "Listed admin subpages via dedicated component",
+        "ru": "Выведены подстраницы админа через специальный компонент"
+      }
     }
   ],
   "daily": {
@@ -262,12 +273,12 @@
       "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
     },
     "2025-08-29": {
-        "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty; added admin login page; added admin logout page and auth checks; translated admin auth message to English; redirected admins to requested page after login",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации на страницах; сообщение авторизации админа переведено на английский; после входа админов перенаправляет на запрошенную страницу"
+        "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty; added admin login page; added admin logout page and auth checks; translated admin auth message to English; redirected admins to requested page after login; listed admin subpages via component",
+      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации на страницах; сообщение авторизации админа переведено на английский; после входа админов перенаправляет на запрошенную страницу; выведены подстраницы админа через компонент"
     }
   },
   "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty; added admin login page; admin logout page and auth checks; login redirect to requested admin page; admin auth message in English",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации; редирект на запрошенную страницу после входа; сообщение авторизации админа на английском"
+    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty; added admin login page; admin logout page and auth checks; login redirect to requested admin page; admin auth message in English; admin subpages listed via component",
+    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации; редирект на запрошенную страницу после входа; сообщение авторизации админа на английском; выведены подстраницы админа"
   }
 }

--- a/src/admin/app/layout.jsx
+++ b/src/admin/app/layout.jsx
@@ -2,6 +2,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
 import BarLeftAdmin from './barLeftAdmin.jsx'
 import { isAdminAuth } from './auth.js'
+import SubPages from './subPages.jsx'
 import './layout.css'
 
 export default function Layout() {
@@ -21,6 +22,7 @@ export default function Layout() {
       <BarLeftAdmin forceCollapsed={isLogin} disableToggle={isLogin} />
       <main>
         <Outlet />
+        <SubPages />
       </main>
     </div>
   )

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -1,0 +1,15 @@
+import AdminPage from '../pages/adminPage.jsx'
+import AdminChartsPage from '../pages/adminChartsPage.jsx'
+import AdminUiPage from '../pages/adminUiPage.jsx'
+import AdminLoginPage from '../pages/adminLoginPage.jsx'
+import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+
+const adminRoutes = [
+  { path: 'login', element: <AdminLoginPage />, label: 'Login' },
+  { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
+  { index: true, element: <AdminPage />, label: 'Home' },
+  { path: 'charts', element: <AdminChartsPage />, label: 'Charts' },
+  { path: 'ui', element: <AdminUiPage />, label: 'UI' },
+]
+
+export default adminRoutes

--- a/src/admin/app/subPages.jsx
+++ b/src/admin/app/subPages.jsx
@@ -1,0 +1,39 @@
+import { Link, useLocation } from 'react-router-dom'
+import adminRoutes from './routes.jsx'
+
+function findRouteChildren(pathname, routes, base = '/admin') {
+  let relative = pathname.startsWith(base) ? pathname.slice(base.length) : pathname
+  if (relative.startsWith('/')) relative = relative.slice(1)
+  const segments = relative.split('/').filter(Boolean)
+  let currentRoutes = routes
+  let currentBase = base
+  for (const segment of segments) {
+    const match = currentRoutes.find(r => r.path === segment)
+    if (!match) return { base: currentBase, routes: [] }
+    currentRoutes = match.children || []
+    currentBase += `/${segment}`
+  }
+  return { base: currentBase, routes: currentRoutes }
+}
+
+export default function SubPages() {
+  const { pathname } = useLocation()
+  const { base, routes } = findRouteChildren(pathname, adminRoutes)
+  const subpages = routes.filter(r => !r.index)
+  if (subpages.length === 0) return null
+  return (
+    <div style={{ marginTop: '2rem' }}>
+      <ul>
+        {subpages.map(r => {
+          const to = `${base}/${r.path || ''}`.replace(/\/+/g, '/').replace(/\/$/, '')
+          const label = r.label || r.path
+          return (
+            <li key={to}>
+              <Link to={to}>{label}</Link>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,11 +6,7 @@ import UserLayout from './user/app/layout.jsx'
 import AdminLayout from './admin/app/layout.jsx'
 import MainPage from './user/pages/mainPage.jsx'
 import ReleaseNotesPage from './user/pages/releaseNotesPage.jsx'
-import AdminPage from './admin/pages/adminPage.jsx'
-import AdminChartsPage from './admin/pages/adminChartsPage.jsx'
-import AdminUiPage from './admin/pages/adminUiPage.jsx'
-import AdminLoginPage from './admin/pages/adminLoginPage.jsx'
-import AdminLogoutPage from './admin/pages/adminLogoutPage.jsx'
+import adminRoutes from './admin/app/routes.jsx'
 
 const router = createBrowserRouter([
   {
@@ -24,13 +20,7 @@ const router = createBrowserRouter([
   {
     path: '/admin',
     element: <AdminLayout />,
-    children: [
-      { path: 'login', element: <AdminLoginPage /> },
-      { path: 'logout', element: <AdminLogoutPage /> },
-      { index: true, element: <AdminPage /> },
-      { path: 'charts', element: <AdminChartsPage /> },
-      { path: 'ui', element: <AdminUiPage /> },
-    ],
+    children: adminRoutes,
   },
 ])
 


### PR DESCRIPTION
## Summary
- show links to subpages at bottom of every admin route using new SubPages component
- centralize admin route definitions and update router
- document subpage listing rule and record change in release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b111c6580c832eb4e2c284072b710a