### PR TITLE
docs: revamp release notes workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.0
+Current version: 0.0.1
 
 ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 Every admin page lists its subpages at the bottom via a dedicated component.
@@ -93,7 +93,7 @@ _Only this section of the readme can be maintained using Russian language_
 10. After completing a task, suggest the next task to complete (don't add this to readme).
 11. Keep the "ACP+Charts now" section up to date by showing only what is already available in the project from the user's perspective. Display the current version: {release_number}.
 12. If there is no indication what language the page should be in, use English.
-13. Update `release-notes.json` for every user-facing change according to `release-notes-howto.md`.
+13. Update `release-notes.json` for every user-facing change according to `release-notes-howto.md`. Assign a weight between 20 and 80 and bump the PATCH version when cutting a release.
 14. Keep user and admin code separated in `/src/user` and `/src/admin`, each containing its own `app` and `pages` directories. Allow duplication between them but record every instance in the "Code duplication log" section.
 15. When a page has nested routes, list its subpages at the end using the dedicated `SubPages` component stored in its own file.
  
@@ -137,7 +137,7 @@ _Only this section of the readme can be maintained using Russian language_
 - `src/user/app/barLeftUser.css` duplicated in `src/admin/app/barLeftAdmin.css`
 
 ## Release notes
-- File `release-notes.json` follows [release-notes-howto.md](release-notes-howto.md).
-- Each user-facing change must append a bilingual entry with ISO 8601 timestamp.
-- Descriptions must use past tense (e.g., "Added release notes page").
-- Keep entries sorted chronologically and update daily summaries and the ultrashort digest.
+- File `release-notes.json` stores an array `releaseNotes` of release objects.
+- Each release has `version`, `date`, `time`, `timezone`, and bilingual `changes` with weights from 20 to 80.
+- Descriptions use past tense and appear in both English (`changes`) and Russian (`changes-ru`).
+- Keep releases sorted chronologically and increment only the PATCH part of the version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes-howto.md
+++ b/release-notes-howto.md
@@ -1,155 +1,44 @@
 # release-notes-howto
 
 ## Purpose
-- Keep a human-friendly and machine-readable history of all notable changes.
-- Provide three built-in views: chronological entries, daily summaries, and an ultra-short digest.
-- Record every message in English (`en`) and Russian (`ru`) to support bilingual interfaces.
+- Maintain a human-readable and machine-readable log of releases.
+- Record every change in both English and Russian.
 
-## Recommended JSON Schema
+## JSON Schema
 ```json
 {
-  "version": "1.0.0",
-  "generated": "2024-01-15T12:00:00+00:00",
-  "changes": [
+  "releaseNotes": [
     {
-      "id": "2024-01-15T08:30:00+00:00-feat-ui",
-      "timestamp": "2024-01-15T08:30:00+00:00",
-      "version": "1.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Add dark-mode toggle",
-        "ru": "Добавлен переключатель тёмной темы"
-      }
+      "version": "0.0.1",
+      "date": "2025-08-29",
+      "time": "13:30:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        { "description": "Added feature", "weight": 40 }
+      ],
+      "changes-ru": [
+        { "description": "Добавлена функция", "weight": 40 }
+      ]
     }
-  ],
-  "daily": {
-    "2024-01-15": {
-      "en": "Introduced dark mode and prepared release pipeline",
-      "ru": "Добавлен тёмный режим и подготовлен релизный процесс"
-    }
-  },
-  "ultrashort": {
-    "en": "Dark mode arrives",
-    "ru": "Появился тёмный режим"
-  }
+  ]
 }
 ```
 
-**Keys**
-- `version`: current semantic version (MAJOR.MINOR.PATCH).
-- `generated`: ISO 8601 timestamp of the file update.
-- `changes`: chronological array of individual change records.
-- `daily`: map of `YYYY-MM-DD` to bilingual daily summaries.
-- `ultrashort`: bilingual digest for quick overviews.
+### Keys
+- `releaseNotes` – array of release objects sorted chronologically.
+- `version` – semantic version (`MAJOR.MINOR.PATCH`). Increment only the PATCH part for each release.
+- `date` – release date in `YYYY-MM-DD` format.
+- `time` – release time in `HH:mm:ss` format.
+- `timezone` – IANA timezone name (e.g., `Asia/Bishkek`).
+- `changes` – English descriptions of changes.
+- `changes-ru` – Russian translations of `changes`.
+- Each change object has `description` and `weight` (20–80 in steps of 10; higher means more important).
 
-**Change object**
-- `id`: unique identifier, typically `<timestamp>-<type>-<scope>`.
-- `timestamp`: ISO 8601 date & time including timezone.
-- `version`: version in which the change is released.
-- `type`: one of `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`.
-- `scope`: one of `ui`, `backend`, `infra`, `docs`, `other`.
-- `description.en` / `description.ru`: short bilingual description.
+### Rules
+1. Append a new release object for every user-facing change set.
+2. List changes in the same order in `changes` and `changes-ru`.
+3. Use past tense and keep descriptions under 80 characters.
+4. Validate JSON with `jq` before committing.
 
-## Rules for Adding Entries
-1. Every commit or ticket that affects users adds an entry to `changes`.
-2. Sort `changes` by ascending `timestamp`.
-3. For each new calendar day, add a `daily["YYYY-MM-DD"]` summary.
-4. Maintain `ultrashort` as a terse digest of recent milestones (max 5 lines per language).
-5. Increment only the PATCH number when cutting a new version.
-6. Keep `type` and `scope` consistent across entries.
-7. Use English technical terms in Russian text when no natural translation exists.
-8. Ensure all timestamps use the same timezone and ISO 8601 format.
+Following this guide keeps release notes simple, bilingual, and properly versioned.
 
-## Updating and Releasing Versions
-- When preparing a release:
-  1. Make sure all pending changes are listed and summarized.
-  2. Increment `version` by 0.0.1.
-  3. Update `generated` with the current timestamp.
-  4. Commit the updated `release-notes.json` with message `chore: release vX.Y.Z`.
-- Do not reset or reorder existing entries; append only.
-
-## Messaging Conventions
-- Keep descriptions under 80 characters.
-- Use past tense and avoid filler words.
-- Bilingual fields must be direct equivalents.
-- Good: `{"en":"Fix login redirect","ru":"Исправлен редирект входа"}`
-- Bad: `{"en":"Some fixes","ru":"Разные правки"}`
-
-## Type and Scope Mapping
-- `feat`: new feature or capability.
-- `fix`: bug fix.
-- `docs`: documentation change.
-- `chore`: build or maintenance task.
-- `refactor`: code restructuring.
-- `perf`: performance improvement.
-- `test`: testing related.
-
-Scopes describe affected area:
-- `ui`: user interface.
-- `backend`: server or API.
-- `infra`: tooling, deployment, CI/CD.
-- `docs`: documentation or guides.
-- `other`: anything else.
-
-Match `type` and `scope` to commit messages or ticket categories to keep release notes searchable.
-
-## Date and Time Requirements
-- Use full ISO 8601 timestamps with timezone, e.g. `2024-01-15T08:30:00+03:00`.
-- Ensure each `id` is unique; combining timestamp, type and scope is recommended.
-- Sort `changes` chronologically; later timestamps come last.
-
-## Templates
-### New Change Entry
-```json
-{
-  "id": "{timestamp}-{type}-{scope}",
-  "timestamp": "{timestamp}",
-  "version": "{currentVersion}",
-  "type": "{type}",
-  "scope": "{scope}",
-  "description": {
-    "en": "{brief English sentence}",
-    "ru": "{краткое русское предложение}"
-  }
-}
-```
-
-### Daily Summary Entry
-```json
-"{YYYY-MM-DD}": {
-  "en": "{English day summary}",
-  "ru": "{Русское дневное резюме}"
-}
-```
-
-### Release Cut
-```json
-{
-  "version": "{newVersion}",
-  "generated": "{now}",
-  ...
-}
-```
-
-## Quality Checks
-- Validate JSON with tools like `jq` or `jsonlint` before committing.
-- Verify chronological order and unique `id` values.
-- Ensure every entry has both `en` and `ru` texts.
-- Keep file encoded in UTF-8 without BOM.
-
-## Common Pitfalls
-- Missing translations or mismatched meanings.
-- Forgetting to update `daily` or `ultrashort` views.
-- Mixing timezones or omitting timezone offsets.
-- Using inconsistent `type` or `scope` values.
-
-## Migration
-1. **Starting fresh**: initialize `release-notes.json` using the schema above with version `0.1.0`.
-2. **Normalizing legacy notes**:
-   - Parse existing notes and assign ISO 8601 timestamps.
-   - Map historical categories to the standard `type` and `scope` sets.
-   - Translate missing languages and split long paragraphs into short entries.
-   - Sort all entries chronologically and generate daily summaries.
-
-Following this guide keeps release notes structured, searchable and ready for automated consumption.

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,284 +1,79 @@
 {
-  "version": "0.0.0",
-  "generated": "2025-08-29T12:30:00+00:00",
-  "changes": [
+  "releaseNotes": [
     {
-      "id": "2025-08-28T09:35:00+00:00-docs-docs",
-      "timestamp": "2025-08-28T09:35:00+00:00",
       "version": "0.0.0",
-      "type": "docs",
-      "scope": "docs",
-      "description": {
-        "en": "Documented release notes rules",
-        "ru": "Добавлены правила ведения release notes"
-      }
+      "date": "2025-08-29",
+      "time": "12:30:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        { "description": "Documented release notes rules", "weight": 20 },
+        { "description": "Added release notes page", "weight": 70 },
+        { "description": "Clarified past tense style for release notes", "weight": 20 },
+        { "description": "Limited release notes page to English", "weight": 30 },
+        { "description": "Separated user and admin menus", "weight": 60 },
+        { "description": "Added collapsible user sidebar", "weight": 60 },
+        { "description": "Darkened sidebar background and fixed icon order", "weight": 40 },
+        { "description": "Implemented dark mode with consistent palette", "weight": 80 },
+        { "description": "Unified page titles with headings", "weight": 40 },
+        { "description": "Fixed release notes layout showing content", "weight": 50 },
+        { "description": "Added login form variants page", "weight": 70 },
+        { "description": "Documented user and admin code separation", "weight": 30 },
+        { "description": "Added collapsible admin sidebar", "weight": 60 },
+        { "description": "Moved login form variants page to admin UI", "weight": 40 },
+        { "description": "Added tooltips and home icon links to sidebars", "weight": 40 },
+        { "description": "Displayed site icon and refreshed home page texts", "weight": 30 },
+        { "description": "Added hashtag display variants on admin UI", "weight": 60 },
+        { "description": "Expanded login and hashtag variants on admin UI", "weight": 60 },
+        { "description": "Marked current UI choices and added ten more form and hashtag variants", "weight": 60 },
+        { "description": "Added admin login page and set login form variant 30 as current choice", "weight": 70 },
+        { "description": "Added admin logout page and enforced auth redirects", "weight": 70 },
+        { "description": "Translated admin auth message to English", "weight": 40 },
+        { "description": "Redirected admins to requested page after login", "weight": 60 },
+        { "description": "Listed admin subpages via dedicated component", "weight": 40 }
+      ],
+      "changes-ru": [
+        { "description": "Добавлены правила ведения release notes", "weight": 20 },
+        { "description": "Добавлена страница release notes", "weight": 70 },
+        { "description": "Уточнён стиль release notes в прошедшем времени", "weight": 20 },
+        { "description": "Страница release notes отображает только английский текст", "weight": 30 },
+        { "description": "Разделены меню пользователя и админа", "weight": 60 },
+        { "description": "Добавлен сворачиваемый сайдбар пользователя", "weight": 60 },
+        { "description": "Утемнён фон сайдбара и закреплён порядок иконок", "weight": 40 },
+        { "description": "Реализован тёмный режим с согласованной палитрой", "weight": 80 },
+        { "description": "Унифицированы тайтлы со страницами", "weight": 40 },
+        { "description": "Исправлено отображение release notes", "weight": 50 },
+        { "description": "Добавлена страница вариантов форм входа", "weight": 70 },
+        { "description": "Задокументировано разделение кода на пользователя и админа", "weight": 30 },
+        { "description": "Добавлен сворачиваемый сайдбар админа", "weight": 60 },
+        { "description": "Перенесена страница вариантов форм входа в админский UI", "weight": 40 },
+        { "description": "Добавлены подсказки и ссылка-домик в сайдбары", "weight": 40 },
+        { "description": "Показана иконка сайта и обновлены тексты главной", "weight": 30 },
+        { "description": "Добавлены варианты отображения хэштегов в админском UI", "weight": 60 },
+        { "description": "Расширены варианты форм входа и хэштегов в админском UI", "weight": 60 },
+        { "description": "Отмечены текущие варианты UI и добавлены ещё десять форм и хэштегов", "weight": 60 },
+        { "description": "Добавлена страница входа админа и выбран вариант формы 30", "weight": 70 },
+        { "description": "Добавлена страница выхода админа и проверка авторизации на страницах", "weight": 70 },
+        { "description": "Сообщение авторизации админа переведено на английский", "weight": 40 },
+        { "description": "После входа админов перенаправляет на запрошенную страницу", "weight": 60 },
+        { "description": "Выведены подстраницы админа через специальный компонент", "weight": 40 }
+      ]
     },
     {
-      "id": "2025-08-28T09:35:30+00:00-feat-ui",
-      "timestamp": "2025-08-28T09:35:30+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Added release notes page",
-        "ru": "Добавлена страница release notes"
-      }
-    },
-    {
-      "id": "2025-08-28T20:28:40+00:00-docs-docs",
-      "timestamp": "2025-08-28T20:28:40+00:00",
-      "version": "0.0.0",
-      "type": "docs",
-      "scope": "docs",
-      "description": {
-        "en": "Clarified past tense style for release notes",
-        "ru": "Уточнён стиль release notes в прошедшем времени"
-      }
-    },
-    {
-      "id": "2025-08-28T20:28:42+00:00-feat-ui",
-      "timestamp": "2025-08-28T20:28:42+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Limited release notes page to English",
-        "ru": "Страница release notes отображает только английский текст"
-      }
-    },
-    {
-      "id": "2025-08-28T20:57:30+00:00-feat-ui",
-      "timestamp": "2025-08-28T20:57:30+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Separated user and admin menus",
-        "ru": "Разделены меню пользователя и админа"
-      }
-    },
-    {
-      "id": "2025-08-28T21:43:30+00:00-feat-ui",
-      "timestamp": "2025-08-28T21:43:30+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Added collapsible user sidebar",
-        "ru": "Добавлен сворачиваемый сайдбар пользователя"
-      }
-    },
-    {
-      "id": "2025-08-28T21:56:43+00:00-feat-ui",
-      "timestamp": "2025-08-28T21:56:43+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Darkened sidebar background and fixed icon order",
-        "ru": "Утемнён фон сайдбара и закреплён порядок иконок"
-      }
-    },
-    {
-      "id": "2025-08-28T22:08:00+00:00-feat-ui",
-      "timestamp": "2025-08-28T22:08:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Implemented dark mode with consistent palette",
-        "ru": "Реализован тёмный режим с согласованной палитрой"
-      }
-    },
-    {
-      "id": "2025-08-29T00:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T00:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Unified page titles with headings",
-        "ru": "Унифицированы тайтлы со страницами"
-      }
-    },
-    {
-      "id": "2025-08-29T00:30:00+00:00-fix-ui",
-      "timestamp": "2025-08-29T00:30:00+00:00",
-      "version": "0.0.0",
-      "type": "fix",
-      "scope": "ui",
-      "description": {
-        "en": "Fixed release notes layout showing content",
-        "ru": "Исправлено отображение release notes"
-      }
-    },
-    {
-      "id": "2025-08-29T01:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T01:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Added login form variants page",
-        "ru": "Добавлена страница вариантов форм входа"
-      }
-    },
-    {
-      "id": "2025-08-29T02:15:00+00:00-docs-docs",
-      "timestamp": "2025-08-29T02:15:00+00:00",
-      "version": "0.0.0",
-      "type": "docs",
-      "scope": "docs",
-      "description": {
-        "en": "Documented user and admin code separation",
-        "ru": "Задокументировано разделение кода на пользователя и админа"
-      }
-    },
-    {
-      "id": "2025-08-29T03:30:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T03:30:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Added collapsible admin sidebar",
-        "ru": "Добавлен сворачиваемый сайдбар админа"
-      }
-    },
-    {
-      "id": "2025-08-29T04:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T04:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Moved login form variants page to admin UI",
-        "ru": "Перенесена страница вариантов форм входа в админский UI"
-      }
-    },
-    {
-      "id": "2025-08-29T05:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T05:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Added tooltips and home icon links to sidebars",
-        "ru": "Добавлены подсказки и ссылка-домик в сайдбары"
-      }
-    },
-    {
-      "id": "2025-08-29T06:30:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T06:30:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Displayed site icon and refreshed home page texts",
-        "ru": "Показана иконка сайта и обновлены тексты главной"
-      }
-    },
-    {
-      "id": "2025-08-29T07:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T07:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Added hashtag display variants on admin UI",
-        "ru": "Добавлены варианты отображения хэштегов в админском UI"
-      }
-    },
-    {
-      "id": "2025-08-29T08:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T08:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Expanded login and hashtag variants on admin UI",
-        "ru": "Расширены варианты форм входа и хэштегов в админском UI"
-      }
-    },
-    {
-      "id": "2025-08-29T09:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T09:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Marked current UI choices and added ten more form and hashtag variants",
-        "ru": "Отмечены текущие варианты UI и добавлены ещё десять форм и хэштегов"
-      }
-    },
-    {
-      "id": "2025-08-29T10:00:00+00:00-feat-auth",
-      "timestamp": "2025-08-29T10:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "auth",
-      "description": {
-        "en": "Added admin login page and set login form variant 30 as current choice",
-        "ru": "Добавлена страница входа админа и выбран вариант формы 30"
-      }
-    },
-    {
-      "id": "2025-08-29T11:00:00+00:00-feat-auth",
-      "timestamp": "2025-08-29T11:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "auth",
-      "description": {
-        "en": "Added admin logout page and enforced auth redirects",
-        "ru": "Добавлена страница выхода админа и проверка авторизации на страницах"
-      }
-    },
-    {
-      "id": "2025-08-29T12:00:00+00:00-fix-i18n",
-      "timestamp": "2025-08-29T12:00:00+00:00",
-      "version": "0.0.0",
-      "type": "fix",
-      "scope": "i18n",
-      "description": {
-        "en": "Translated admin auth message to English",
-        "ru": "Сообщение авторизации админа переведено на английский"
-      }
-    },
-    {
-      "id": "2025-08-29T12:30:00+00:00-feat-auth",
-      "timestamp": "2025-08-29T12:30:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "auth",
-      "description": {
-        "en": "Redirected admins to requested page after login",
-        "ru": "После входа админов перенаправляет на запрошенную страницу"
-      }
-    },
-    {
-      "id": "2025-08-29T13:00:00+00:00-feat-ui",
-      "timestamp": "2025-08-29T13:00:00+00:00",
-      "version": "0.0.0",
-      "type": "feat",
-      "scope": "ui",
-      "description": {
-        "en": "Listed admin subpages via dedicated component",
-        "ru": "Выведены подстраницы админа через специальный компонент"
-      }
+      "version": "0.0.1",
+      "date": "2025-08-29",
+      "time": "13:30:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        { "description": "Introduced weighted release notes format with versioning", "weight": 50 },
+        { "description": "Clarified release note workflow in documentation", "weight": 30 },
+        { "description": "Expanded README instructions for maintaining release notes", "weight": 20 }
+      ],
+      "changes-ru": [
+        { "description": "Введён формат release notes с весами и версиями", "weight": 50 },
+        { "description": "Уточнён процесс ведения release notes в документации", "weight": 30 },
+        { "description": "Расширены инструкции по release notes в README", "weight": 20 }
+      ]
     }
-  ],
-  "daily": {
-    "2025-08-28": {
-      "en": "Release notes page shows English only; rules and style clarified; separated user and admin menus; added collapsible user sidebar; darkened sidebar and stabilized icons; implemented dark mode",
-      "ru": "Страница release notes показывает только английский текст; уточнены правила и стиль; разделены меню пользователя и админа; добавлен сворачиваемый пользовательский сайдбар; затемнён сайдбар и упорядочены иконки; реализован тёмный режим"
-    },
-    "2025-08-29": {
-        "en": "Aligned page titles with headings; fixed release notes layout; added login form variants page; documented user/admin code separation; added collapsible admin sidebar; moved login form variants page to admin UI; added sidebar tooltips and home links; displayed site icon and refreshed home page texts; added hashtag display variants on admin UI; expanded login and hashtag variants; marked current UI selections and extended variants to thirty; added admin login page; added admin logout page and auth checks; translated admin auth message to English; redirected admins to requested page after login; listed admin subpages via component",
-      "ru": "Синхронизированы тайтлы с заголовками; исправлено отображение release notes; добавлена страница вариантов форм входа; задокументировано разделение кода на пользователя и админа; добавлен сворачиваемый сайдбар админа; страница вариантов форм входа перенесена в админский UI; добавлены подсказки и ссылка-домик в сайдбары; показана иконка сайта и обновлены тексты главной; добавлены варианты отображения хэштегов в админском UI; расширены варианты форм входа и хэштегов; отмечены текущие варианты UI и увеличено число вариантов до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации на страницах; сообщение авторизации админа переведено на английский; после входа админов перенаправляет на запрошенную страницу; выведены подстраницы админа через компонент"
-    }
-  },
-  "ultrashort": {
-    "en": "Release notes English-only; split user/admin menus; collapsible sidebar; dark mode; unified page titles; fixed release notes layout; login form variants page; documented code separation; collapsible admin sidebar; login forms moved to admin UI; sidebar tooltips and home links; home page icon and greeting updated; hashtag display variants; expanded login and hashtag variants; marked current choices and raised variants to thirty; added admin login page; admin logout page and auth checks; login redirect to requested admin page; admin auth message in English; admin subpages listed via component",
-    "ru": "Release notes только на английском; разделены меню; добавлен сворачиваемый сайдбар; тёмный режим; унификация тайтлов; исправлено отображение release notes; страница вариантов форм входа; задокументировано разделение кода; сворачиваемый сайдбар админа; страница форм входа перенесена в админский UI; подсказки и ссылка-домик в сайдбары; обновлена иконка и приветствие на главной; варианты отображения хэштегов; расширены варианты форм входа и хэштегов; отмечены текущие варианты и число вариантов увеличено до тридцати; добавлена страница входа админа; добавлена страница выхода админа и проверка авторизации; редирект на запрошенную страницу после входа; сообщение авторизации админа на английском; выведены подстраницы админа"
-  }
+  ]
 }
+


### PR DESCRIPTION
## Summary
- replace release notes schema with weighted `releaseNotes` array
- document new format and update README instructions
- bump project version to 0.0.1

## Testing
- `jq . release-notes.json`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b116c18c98832e80e764bff36b34c2