### PR TITLE
fix: clarify admin auth message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.29
+Current version: 0.0.30
 
 ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 Every admin page lists its subpages at the bottom via a dedicated component.
@@ -21,6 +21,7 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 2.4 Проверять авторизацию на всех страницах /admin/*. Если нет авторизации, то редирект на /admin/login .
   - [x] 2.5 Добавить страницу /admin/logout, сообщение об успешной авторизации и ссылку на выход.
   - [x] 2.6 Возвращать на запрошенную страницу /admin/* после успешной авторизации.
+  - [x] 2.7 Обновить сообщение об успешной авторизации на "User admin is authenticated. You can log out."
 
 3. Графики
   - [ ] 3.1 Создать /admin/dev/charts . Создать /admin/dev/ , которая редиректит на /admin/dev/charts .

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.29",
+  "version": "0.0.30",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -639,6 +639,28 @@
       ]
     },
     {
+      "version": "0.0.30",
+      "date": "2025-08-29",
+      "time": "09:29:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Rephrased admin authentication message for clarity",
+          "weight": 20,
+          "type": "fix",
+          "scope": "auth-message"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Переформулировано сообщение об авторизации админа",
+          "weight": 20,
+          "type": "fix",
+          "scope": "auth-message"
+        }
+      ]
+    },
+    {
       "date": "2025-08-29",
       "time": "summary",
       "summary": [
@@ -650,7 +672,8 @@
         "Code separation documented and release notes instructions clarified",
         "Admin subpages listed via dedicated component",
         "Release notes page crash resolved",
-        "Release notes tagged with type and scope"
+        "Release notes tagged with type and scope",
+        "Admin auth message refined"
       ],
       "summary-ru": [
         "Задокументированы правила и страница release notes, уточнён процесс",
@@ -661,7 +684,8 @@
         "Задокументировано разделение кода и уточнены инструкции по release notes",
         "Подстраницы админа выведены через отдельный компонент",
         "Исправлено падение страницы release notes",
-        "Release notes получили теги type и scope"
+        "Release notes получили теги type и scope",
+        "Уточнено сообщение об авторизации админа"
       ],
       "ultrashort-summary": [
         "Release notes documented",
@@ -672,7 +696,8 @@
         "Code docs updated",
         "Admin subpages listed",
         "Release notes crash fixed",
-        "Type and scope tags"
+        "Type and scope tags",
+        "Auth message refined"
       ],
       "ultrashort-summary-ru": [
         "Документы release notes",
@@ -683,7 +708,8 @@
         "Документация обновлена",
         "Подстраницы админа",
         "Исправлен crash release notes",
-        "Теги type и scope"
+        "Теги type и scope",
+        "Сообщение авторизации уточнено"
       ]
     }
   ],
@@ -1323,6 +1349,28 @@
           "type": "feat",
           "scope": "release-notes",
           "weight": 40
+        }
+      ]
+    },
+    {
+      "version": "0.0.30",
+      "date": "2025-08-29",
+      "time": "09:29:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Rephrased admin authentication message for clarity",
+          "weight": 20,
+          "type": "fix",
+          "scope": "auth-message"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Переформулировано сообщение об авторизации админа",
+          "weight": 20,
+          "type": "fix",
+          "scope": "auth-message"
         }
       ]
     }

--- a/src/admin/app/authMessage.jsx
+++ b/src/admin/app/authMessage.jsx
@@ -6,7 +6,7 @@ export default function AuthMessage() {
   if (!isAdminAuth()) return null
   return (
     <p>
-      {login} is authenticated, <Link to="/admin/logout">log out</Link>
+      User {login} is authenticated. You can <Link to="/admin/logout">log out</Link>.
     </p>
   )
 }


### PR DESCRIPTION
## Summary
- clarify admin auth confirmation text and keep logout as link
- document auth message change in release notes and bump version to 0.0.30

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b131220c54832e9b229ae6874a5d61