### PR TITLE
style: refine admin titles and h1 size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.30
+Current version: 0.0.31
 
 ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 Every admin page lists its subpages at the bottom via a dedicated component.
@@ -77,6 +77,10 @@ _Only this section of the readme can be maintained using Russian language_
  - [x] 13.1 Добавить иконку перед названием
  - [x] 13.2 Заменить текст приветствия
  - [x] 13.3 Обновить ссылку /admin
+
+# 14. Правки оформления
+ - [x] 14.1 Изменить заголовок админских страниц на "| Admin Control Panel |"
+ - [x] 14.2 Уменьшить глобальный размер h1 до 2.4em
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.30",
+  "version": "0.0.31",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -661,6 +661,40 @@
       ]
     },
     {
+      "version": "0.0.31",
+      "date": "2025-08-29",
+      "time": "09:30:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Renamed admin titles to 'Admin Control Panel'",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin-title"
+        },
+        {
+          "description": "Reduced global h1 font size to 2.4em",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Переименованы админские заголовки в 'Admin Control Panel'",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin-title"
+        },
+        {
+          "description": "Уменьшен глобальный размер h1 до 2.4em",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
       "date": "2025-08-29",
       "time": "summary",
       "summary": [
@@ -673,7 +707,8 @@
         "Admin subpages listed via dedicated component",
         "Release notes page crash resolved",
         "Release notes tagged with type and scope",
-        "Admin auth message refined"
+        "Admin auth message refined",
+        "Admin titles clarified and h1 size reduced"
       ],
       "summary-ru": [
         "Задокументированы правила и страница release notes, уточнён процесс",
@@ -685,7 +720,8 @@
         "Подстраницы админа выведены через отдельный компонент",
         "Исправлено падение страницы release notes",
         "Release notes получили теги type и scope",
-        "Уточнено сообщение об авторизации админа"
+        "Уточнено сообщение об авторизации админа",
+        "Уточнены заголовки админ-панели и уменьшен размер h1"
       ],
       "ultrashort-summary": [
         "Release notes documented",
@@ -697,7 +733,8 @@
         "Admin subpages listed",
         "Release notes crash fixed",
         "Type and scope tags",
-        "Auth message refined"
+        "Auth message refined",
+        "Admin titles & h1 size"
       ],
       "ultrashort-summary-ru": [
         "Документы release notes",
@@ -709,7 +746,8 @@
         "Подстраницы админа",
         "Исправлен crash release notes",
         "Теги type и scope",
-        "Сообщение авторизации уточнено"
+        "Сообщение авторизации уточнено",
+        "Заголовки и h1"
       ]
     }
   ],
@@ -1371,6 +1409,40 @@
           "weight": 20,
           "type": "fix",
           "scope": "auth-message"
+        }
+      ]
+    },
+    {
+      "version": "0.0.31",
+      "date": "2025-08-29",
+      "time": "09:30:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Renamed admin titles to 'Admin Control Panel'",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin-title"
+        },
+        {
+          "description": "Reduced global h1 font size to 2.4em",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Переименованы админские заголовки в 'Admin Control Panel'",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin-title"
+        },
+        {
+          "description": "Уменьшен глобальный размер h1 до 2.4em",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
         }
       ]
     }

--- a/src/admin/pages/adminChartsPage.jsx
+++ b/src/admin/pages/adminChartsPage.jsx
@@ -3,7 +3,7 @@ import AuthMessage from '../app/authMessage.jsx'
 
 export default function AdminChartsPage() {
   const title = 'Admin Charts Page'
-  const fullTitle = `${title} | Admin | ACPC`
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
   useEffect(() => {
     document.title = fullTitle
   }, [fullTitle])

--- a/src/admin/pages/adminPage.jsx
+++ b/src/admin/pages/adminPage.jsx
@@ -3,7 +3,7 @@ import AuthMessage from '../app/authMessage.jsx'
 
 export default function AdminPage() {
   const title = 'Admin Page'
-  const fullTitle = `${title} | Admin | ACPC`
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
   useEffect(() => {
     document.title = fullTitle
   }, [fullTitle])

--- a/src/index.css
+++ b/src/index.css
@@ -92,10 +92,10 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
+  h1 {
+    font-size: 2.4em;
+    line-height: 1.1;
+  }
 
 header {
   background-color: var(--color-surface);


### PR DESCRIPTION
## Summary
- Rename admin page titles to use "Admin Control Panel"
- Reduce global h1 font size to 2.4em
- Document changes in README and release notes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b132ef4c9c832e9be5f8cd227358b5