### PR TITLE
fix: label admin subpage lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.31
+Current version: 0.0.32
 
 ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 Every admin page lists its subpages at the bottom via a dedicated component.
@@ -81,6 +81,7 @@ _Only this section of the readme can be maintained using Russian language_
 # 14. Правки оформления
  - [x] 14.1 Изменить заголовок админских страниц на "| Admin Control Panel |"
  - [x] 14.2 Уменьшить глобальный размер h1 до 2.4em
+ - [x] 14.3 Добавить префикс "Subpages:" перед списком подстраниц в /admin/*
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.31",
+  "version": "0.0.32",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -695,6 +695,28 @@
       ]
     },
     {
+      "version": "0.0.32",
+      "date": "2025-08-29",
+      "time": "09:31:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Prefixed admin subpage lists with 'Subpages:'",
+          "weight": 20,
+          "type": "fix",
+          "scope": "admin-ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Перед списками подстраниц админа добавлен префикс \"Subpages:\"",
+          "weight": 20,
+          "type": "fix",
+          "scope": "admin-ui"
+        }
+      ]
+    },
+    {
       "date": "2025-08-29",
       "time": "summary",
       "summary": [
@@ -708,7 +730,8 @@
         "Release notes page crash resolved",
         "Release notes tagged with type and scope",
         "Admin auth message refined",
-        "Admin titles clarified and h1 size reduced"
+        "Admin titles clarified and h1 size reduced",
+        "Admin subpage lists labeled with 'Subpages:'"
       ],
       "summary-ru": [
         "Задокументированы правила и страница release notes, уточнён процесс",
@@ -721,7 +744,8 @@
         "Исправлено падение страницы release notes",
         "Release notes получили теги type и scope",
         "Уточнено сообщение об авторизации админа",
-        "Уточнены заголовки админ-панели и уменьшен размер h1"
+        "Уточнены заголовки админ-панели и уменьшен размер h1",
+        "Списки подстраниц админа теперь начинаются с \"Subpages:\""
       ],
       "ultrashort-summary": [
         "Release notes documented",
@@ -734,7 +758,8 @@
         "Release notes crash fixed",
         "Type and scope tags",
         "Auth message refined",
-        "Admin titles & h1 size"
+        "Admin titles & h1 size",
+        "Subpages label added"
       ],
       "ultrashort-summary-ru": [
         "Документы release notes",
@@ -747,7 +772,8 @@
         "Исправлен crash release notes",
         "Теги type и scope",
         "Сообщение авторизации уточнено",
-        "Заголовки и h1"
+        "Заголовки и h1",
+        "Подпись Subpages"
       ]
     }
   ],
@@ -1443,6 +1469,28 @@
           "weight": 30,
           "type": "style",
           "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.32",
+      "date": "2025-08-29",
+      "time": "09:31:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Prefixed admin subpage lists with 'Subpages:'",
+          "weight": 20,
+          "type": "fix",
+          "scope": "admin-ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Перед списками подстраниц админа добавлен префикс \"Subpages:\"",
+          "weight": 20,
+          "type": "fix",
+          "scope": "admin-ui"
         }
       ]
     }

--- a/src/admin/app/subPages.jsx
+++ b/src/admin/app/subPages.jsx
@@ -23,6 +23,7 @@ export default function SubPages() {
   if (subpages.length === 0) return null
   return (
     <div style={{ marginTop: '2rem' }}>
+      <h2>Subpages:</h2>
       <ul>
         {subpages.map(r => {
           const to = `${base}/${r.path || ''}`.replace(/\/+/g, '/').replace(/\/$/, '')


### PR DESCRIPTION
## Summary
- show "Subpages:" heading before admin subpage lists
- document heading addition in README and release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b13476dd00832e874aecd273d33176