### PR TITLE
docs: reorganize features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.32
+Current version: 0.0.33
 
 ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
 Every admin page lists its subpages at the bottom via a dedicated component.
@@ -24,10 +24,8 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 2.7 Обновить сообщение об успешной авторизации на "User admin is authenticated. You can log out."
 
 3. Графики
-  - [ ] 3.1 Создать /admin/dev/charts . Создать /admin/dev/ , которая редиректит на /admin/dev/charts .
-  - [x] 3.2 Добавить правило для ботов в readme, что если есть вложенные страницы, то использовать специальный компонент для вывода подстраниц согласно схеме роутинга. Хранить этот компоент в отдельном файле.
-  - [ ] 3.2.1 Создать страницу /admin/dev/charts/recharts и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Recharts. После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
-  - [ ] 3.2.2 Создать страницу /admin/dev/charts/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
+  - [ ] 3.1 Создать страницу /admin/dev/charts/recharts и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Recharts. После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
+  - [ ] 3.2 Создать страницу /admin/dev/charts/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
 
 6. Удобства
  - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.
@@ -36,6 +34,7 @@ _Only this section of the readme can be maintained using Russian language_
   - - [ ] 6.2.1 Переключатель: релизы только по времени или релизы только по дням или кратчайшие релизы. Состояние переключателя при переключение сохранять в localstorage. (Создать /servises/localstorageHelper.jsx для лаконичного взаимодействия с localstorage.)
   - - [x] 6.2.2 Исправить отображение содержимого на /release-notes.
  - [x] 6.3 Добавить type и scope к записям release notes и вывести их на странице /release-notes.
+ - [x] 6.4 Добавить правило для ботов в readme, что если есть вложенные страницы, то использовать специальный компонент для вывода подстраниц согласно схеме роутинга. Хранить этот компонент в отдельном файле.
 
 
 7. Recommendations from bot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.1",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.1",
+      "version": "0.0.33",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.32",
+  "version": "0.0.33",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -717,6 +717,28 @@
       ]
     },
     {
+      "version": "0.0.33",
+      "date": "2025-08-29",
+      "time": "09:32:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Reorganized Features ToDo and relocated bot guideline to conveniences",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Перенесено правило бота в раздел удобств и обновлён список Features ToDo",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ]
+    },
+    {
       "date": "2025-08-29",
       "time": "summary",
       "summary": [
@@ -731,7 +753,8 @@
         "Release notes tagged with type and scope",
         "Admin auth message refined",
         "Admin titles clarified and h1 size reduced",
-        "Admin subpage lists labeled with 'Subpages:'"
+        "Admin subpage lists labeled with 'Subpages:'",
+        "Features list reorganized and bot rule moved to conveniences"
       ],
       "summary-ru": [
         "Задокументированы правила и страница release notes, уточнён процесс",
@@ -745,7 +768,8 @@
         "Release notes получили теги type и scope",
         "Уточнено сообщение об авторизации админа",
         "Уточнены заголовки админ-панели и уменьшен размер h1",
-        "Списки подстраниц админа теперь начинаются с \"Subpages:\""
+        "Списки подстраниц админа теперь начинаются с \"Subpages:\"",
+        "Перенесено правило бота в раздел удобств и обновлён список Features ToDo"
       ],
       "ultrashort-summary": [
         "Release notes documented",
@@ -759,7 +783,8 @@
         "Type and scope tags",
         "Auth message refined",
         "Admin titles & h1 size",
-        "Subpages label added"
+        "Subpages label added",
+        "Features list updated"
       ],
       "ultrashort-summary-ru": [
         "Документы release notes",
@@ -773,7 +798,8 @@
         "Теги type и scope",
         "Сообщение авторизации уточнено",
         "Заголовки и h1",
-        "Подпись Subpages"
+        "Подпись Subpages",
+        "Обновлён список задач"
       ]
     }
   ],
@@ -1491,6 +1517,29 @@
           "weight": 20,
           "type": "fix",
           "scope": "admin-ui"
+        }
+      ]
+    }
+    ,
+    {
+      "version": "0.0.33",
+      "date": "2025-08-29",
+      "time": "09:32:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Reorganized Features ToDo and relocated bot guideline to conveniences",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Перенесено правило бота в раздел удобств и обновлён список Features ToDo",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove obsolete chart dev entry and shift detailed chart page tasks to proper numbering
- move completed bot guideline into conveniences section
- document changes in release notes and bump version to 0.0.33

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b13e4d385c832e8fff932d941680fb