### PR TITLE
docs: condense README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # ACP+Charts now
-Current version: 0.0.33
+Current version: 0.0.34
 
-ACP+Charts is a minimal React + Vite app with basic routing. Users can navigate between a main page and a release notes page showing updates in English. Administrators can log in at `/admin/login` using credentials stored in environment variables and then access a dashboard, a charts screen, and a UI page with thirty login form variants and thirty hashtag variants. They can log out at `/admin/logout`, and all admin routes redirect to the login page if not authenticated. After login, admins return to the page they originally requested. Non-admin pages feature a collapsible left sidebar with navigation links and icons, while admin pages use a separate collapsible admin menu. Icons provide tooltips and include a home link. User code resides in `src/user` and admin code in `src/admin`, each with their own `app` and `pages` subfolders.
-Every admin page lists its subpages at the bottom via a dedicated component.
+- Minimal React + Vite app with basic routing
+- Public pages: home and English release notes
+- Admin login at `/admin/login` using env credentials
+- Admin access to dashboard, charts, and UI demos of 30 forms and 30 hashtags
+- Logout at `/admin/logout` with redirect for unauthenticated routes
+- Return to originally requested admin page after login
+- Public pages use a collapsible sidebar with icon tooltips and home link
+- Admin pages have a separate collapsible menu
+- Code split between `src/user` and `src/admin`
+- Admin pages list subpages via dedicated component
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.33",
+  "version": "0.0.34",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -739,6 +739,28 @@
       ]
     },
     {
+      "version": "0.0.34",
+      "date": "2025-08-29",
+      "time": "09:33:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Condensed ACP+Charts now section into concise bullet list",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сокращён раздел ACP+Charts now до краткого маркированного списка",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ]
+    },
+    {
       "date": "2025-08-29",
       "time": "summary",
       "summary": [
@@ -754,7 +776,8 @@
         "Admin auth message refined",
         "Admin titles clarified and h1 size reduced",
         "Admin subpage lists labeled with 'Subpages:'",
-        "Features list reorganized and bot rule moved to conveniences"
+        "Features list reorganized and bot rule moved to conveniences",
+        "README intro shortened into bullet list"
       ],
       "summary-ru": [
         "Задокументированы правила и страница release notes, уточнён процесс",
@@ -769,7 +792,8 @@
         "Уточнено сообщение об авторизации админа",
         "Уточнены заголовки админ-панели и уменьшен размер h1",
         "Списки подстраниц админа теперь начинаются с \"Subpages:\"",
-        "Перенесено правило бота в раздел удобств и обновлён список Features ToDo"
+        "Перенесено правило бота в раздел удобств и обновлён список Features ToDo",
+        "Введение README сокращено до маркированного списка"
       ],
       "ultrashort-summary": [
         "Release notes documented",
@@ -784,7 +808,8 @@
         "Auth message refined",
         "Admin titles & h1 size",
         "Subpages label added",
-        "Features list updated"
+        "Features list updated",
+        "README intro concise"
       ],
       "ultrashort-summary-ru": [
         "Документы release notes",
@@ -799,7 +824,8 @@
         "Сообщение авторизации уточнено",
         "Заголовки и h1",
         "Подпись Subpages",
-        "Обновлён список задач"
+        "Обновлён список задач",
+        "Краткое введение README"
       ]
     }
   ],
@@ -1537,6 +1563,28 @@
       "changes-ru": [
         {
           "description": "Перенесено правило бота в раздел удобств и обновлён список Features ToDo",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ]
+    },
+    {
+      "version": "0.0.34",
+      "date": "2025-08-29",
+      "time": "09:33:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Condensed ACP+Charts now section into concise bullet list",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сокращён раздел ACP+Charts now до краткого маркированного списка",
           "weight": 20,
           "type": "docs",
           "scope": "readme"


### PR DESCRIPTION
## Summary
- present ACP+Charts now section as concise bullet list
- bump to version 0.0.34 and log docs change in release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b14314b220832e89d1cf2f60bd32da