### PR TITLE
feat: add Recharts user charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.34
+Current version: 0.0.35
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -11,6 +11,7 @@ Current version: 0.0.34
 - Admin pages have a separate collapsible menu
 - Code split between `src/user` and `src/admin`
 - Admin pages list subpages via dedicated component
+- Admin dev charts with 20 Recharts examples for users data
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -32,8 +33,8 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 2.7 Обновить сообщение об успешной авторизации на "User admin is authenticated. You can log out."
 
 3. Графики
-  - [ ] 3.1 Создать страницу /admin/dev/charts/recharts и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Recharts. После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
-  - [ ] 3.2 Создать страницу /admin/dev/charts/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из mockData.js.
+  - [x] 3.1 Создать страницы /admin/dev/charts/users и /admin/dev/charts/users/recharts с 20 вариантами графиков на Recharts. После каждого графика добавить описание и пример кода в textarea. Данные автоматически берутся из public/mocks/users.json.
+  - [ ] 3.2 Создать страницу /admin/dev/charts/users/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из public/mocks/users.json.
 
 6. Удобства
  - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.
@@ -131,6 +132,7 @@ _Only this section of the readme can be maintained using Russian language_
 - react-dom 19.1.1
 - react-feather 2.0.10
 - react-router-dom 7.8.2
+- recharts 2.15.4
 
 **Dev dependencies**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "acpc",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-feather": "^2.0.10",
-        "react-router-dom": "^7.8.2"
+        "react-router-dom": "^7.8.2",
+        "recharts": "^2.15.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -274,6 +275,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1357,6 +1367,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1574,6 +1647,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1636,8 +1718,128 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1657,12 +1859,28 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.209",
@@ -1914,12 +2132,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2102,6 +2335,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2237,6 +2479,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2579,6 +2827,75 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2710,6 +3027,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -2779,6 +3102,28 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.34",
+  "version": "0.0.35",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"
@@ -16,7 +16,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-feather": "^2.0.10",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "recharts": "^2.15.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/release-notes.json
+++ b/release-notes.json
@@ -761,6 +761,40 @@
       ]
     },
     {
+      "version": "0.0.35",
+      "date": "2025-08-29",
+      "time": "09:34:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added 20 Recharts examples for user data",
+          "weight": 70,
+          "type": "feat",
+          "scope": "charts"
+        },
+        {
+          "description": "Documented new charts routes in README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено 20 примеров графиков Recharts для данных пользователей",
+          "weight": 70,
+          "type": "feat",
+          "scope": "charts"
+        },
+        {
+          "description": "Задокументированы новые маршруты графиков в README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ]
+    },
+    {
       "date": "2025-08-29",
       "time": "summary",
       "summary": [
@@ -777,7 +811,8 @@
         "Admin titles clarified and h1 size reduced",
         "Admin subpage lists labeled with 'Subpages:'",
         "Features list reorganized and bot rule moved to conveniences",
-        "README intro shortened into bullet list"
+        "README intro shortened into bullet list",
+        "User charts with Recharts"
       ],
       "summary-ru": [
         "Задокументированы правила и страница release notes, уточнён процесс",
@@ -793,7 +828,8 @@
         "Уточнены заголовки админ-панели и уменьшен размер h1",
         "Списки подстраниц админа теперь начинаются с \"Subpages:\"",
         "Перенесено правило бота в раздел удобств и обновлён список Features ToDo",
-        "Введение README сокращено до маркированного списка"
+        "Введение README сокращено до маркированного списка",
+        "Добавлены демо графиков пользователей на Recharts"
       ],
       "ultrashort-summary": [
         "Release notes documented",
@@ -809,7 +845,8 @@
         "Admin titles & h1 size",
         "Subpages label added",
         "Features list updated",
-        "README intro concise"
+        "README intro concise",
+        "Recharts user charts"
       ],
       "ultrashort-summary-ru": [
         "Документы release notes",
@@ -825,7 +862,42 @@
         "Заголовки и h1",
         "Подпись Subpages",
         "Обновлён список задач",
-        "Краткое введение README"
+        "Краткое введение README",
+        "Графики Recharts"
+      ]
+    },
+    {
+      "version": "0.0.35",
+      "date": "2025-08-29",
+      "time": "09:34:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added 20 Recharts examples for user data",
+          "weight": 70,
+          "type": "feat",
+          "scope": "charts"
+        },
+        {
+          "description": "Documented new charts routes in README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено 20 примеров графиков Recharts для данных пользователей",
+          "weight": 70,
+          "type": "feat",
+          "scope": "charts"
+        },
+        {
+          "description": "Задокументированы новые маршруты графиков в README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
       ]
     }
   ],
@@ -1545,8 +1617,7 @@
           "scope": "admin-ui"
         }
       ]
-    }
-    ,
+    },
     {
       "version": "0.0.33",
       "date": "2025-08-29",
@@ -1585,6 +1656,40 @@
       "changes-ru": [
         {
           "description": "Сокращён раздел ACP+Charts now до краткого маркированного списка",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ]
+    },
+    {
+      "version": "0.0.35",
+      "date": "2025-08-29",
+      "time": "09:34:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added 20 Recharts examples for user data",
+          "weight": 70,
+          "type": "feat",
+          "scope": "charts"
+        },
+        {
+          "description": "Documented new charts routes in README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено 20 примеров графиков Recharts для данных пользователей",
+          "weight": 70,
+          "type": "feat",
+          "scope": "charts"
+        },
+        {
+          "description": "Задокументированы новые маршруты графиков в README",
           "weight": 20,
           "type": "docs",
           "scope": "readme"

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -78,6 +78,7 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
         <nav className="sidebar-content">
           <Link to="/admin">/admin</Link>
           <Link to="/admin/charts">/admin/charts</Link>
+          <Link to="/admin/dev">/admin/dev</Link>
           <Link to="/admin/ui">/admin/ui</Link>
           <Link to="/admin/logout">/admin/logout</Link>
         </nav>

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -3,12 +3,40 @@ import AdminChartsPage from '../pages/adminChartsPage.jsx'
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+import AdminDevPage from '../pages/adminDevPage.jsx'
+import AdminDevChartsPage from '../pages/adminDevChartsPage.jsx'
+import AdminDevChartsUsersPage from '../pages/adminDevChartsUsersPage.jsx'
+import AdminDevChartsUsersRechartsPage from '../pages/adminDevChartsUsersRechartsPage.jsx'
+import AdminDevChartsUsersChartjs2Page from '../pages/adminDevChartsUsersChartjs2Page.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
   { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
   { index: true, element: <AdminPage />, label: 'Home' },
   { path: 'charts', element: <AdminChartsPage />, label: 'Charts' },
+  {
+    path: 'dev',
+    element: <AdminDevPage />,
+    label: 'Dev',
+    children: [
+      {
+        path: 'charts',
+        element: <AdminDevChartsPage />,
+        label: 'Charts',
+        children: [
+          {
+            path: 'users',
+            element: <AdminDevChartsUsersPage />,
+            label: 'Users',
+            children: [
+              { path: 'recharts', element: <AdminDevChartsUsersRechartsPage />, label: 'Recharts' },
+              { path: 'chartjs2', element: <AdminDevChartsUsersChartjs2Page />, label: 'Chartjs2' }
+            ]
+          }
+        ]
+      }
+    ]
+  },
   { path: 'ui', element: <AdminUiPage />, label: 'UI' },
 ]
 

--- a/src/admin/pages/adminDevChartsPage.jsx
+++ b/src/admin/pages/adminDevChartsPage.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+
+export default function AdminDevChartsPage() {
+  const title = 'Admin Dev Charts Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+    </div>
+  )
+}

--- a/src/admin/pages/adminDevChartsUsersChartjs2Page.jsx
+++ b/src/admin/pages/adminDevChartsUsersChartjs2Page.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+
+export default function AdminDevChartsUsersChartjs2Page() {
+  const title = 'Admin Dev Charts Users Chartjs2 Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <p>Chart.js 2 examples are not implemented yet.</p>
+    </div>
+  )
+}

--- a/src/admin/pages/adminDevChartsUsersPage.jsx
+++ b/src/admin/pages/adminDevChartsUsersPage.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+
+export default function AdminDevChartsUsersPage() {
+  const title = 'Admin Dev Charts Users Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+    </div>
+  )
+}

--- a/src/admin/pages/adminDevChartsUsersRechartsPage.jsx
+++ b/src/admin/pages/adminDevChartsUsersRechartsPage.jsx
@@ -1,0 +1,527 @@
+import { useEffect, useState, useMemo } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  LineChart, Line,
+  AreaChart, Area,
+  PieChart, Pie, Cell,
+  RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
+  RadialBarChart, RadialBar,
+  ScatterChart, Scatter,
+  Treemap,
+  ComposedChart,
+  Brush,
+  ResponsiveContainer
+} from 'recharts'
+
+export default function AdminDevChartsUsersRechartsPage() {
+  const title = 'Admin Dev Charts Users Recharts Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [users, setUsers] = useState([])
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    fetch('/mocks/users.json').then(r => r.json()).then(setUsers)
+  }, [])
+
+  function aggregate(arr, key) {
+    const counts = {}
+    arr.forEach(u => {
+      const val = u[key]
+      counts[val] = (counts[val] || 0) + 1
+    })
+    return Object.entries(counts).map(([name, value]) => ({ name, value }))
+  }
+
+  function aggregateDate(arr, key) {
+    const counts = {}
+    arr.forEach(u => {
+      const month = u[key].slice(0, 7)
+      counts[month] = (counts[month] || 0) + 1
+    })
+    return Object.entries(counts)
+      .map(([month, value]) => ({ month, value }))
+      .sort((a, b) => a.month.localeCompare(b.month))
+  }
+
+  const planData = useMemo(() => aggregate(users, 'plan'), [users])
+  const statusData = useMemo(() => aggregate(users, 'status'), [users])
+  const deviceData = useMemo(() => aggregate(users, 'device'), [users])
+  const browserData = useMemo(() => aggregate(users, 'browser'), [users])
+  const osData = useMemo(() => aggregate(users, 'os'), [users])
+  const cityData = useMemo(() => aggregate(users, 'city').slice(0, 10), [users])
+  const signupByMonth = useMemo(() => aggregateDate(users, 'createdAt'), [users])
+  const activeByMonth = useMemo(() => aggregateDate(users, 'lastActiveAt'), [users])
+
+  const monthlyData = useMemo(() => {
+    const map = {}
+    signupByMonth.forEach(({ month, value }) => {
+      if (!map[month]) map[month] = { month }
+      map[month].signups = value
+    })
+    activeByMonth.forEach(({ month, value }) => {
+      if (!map[month]) map[month] = { month }
+      map[month].active = value
+    })
+    return Object.values(map).sort((a, b) => a.month.localeCompare(b.month))
+  }, [signupByMonth, activeByMonth])
+
+  const planStatusData = useMemo(() => {
+    const map = {}
+    users.forEach(u => {
+      if (!map[u.plan]) map[u.plan] = { name: u.plan }
+      map[u.plan][u.status] = (map[u.plan][u.status] || 0) + 1
+    })
+    return Object.values(map)
+  }, [users])
+
+  const scatterData = useMemo(() => users.map(u => ({
+    x: u.id,
+    y: new Date(u.lastActiveAt) - new Date(u.createdAt)
+  })), [users])
+
+  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#413ea0', '#ff0000']
+
+  function ChartExample({ title, description, code, children }) {
+    return (
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>{title}</h3>
+        <p>{description}</p>
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            {children}
+          </ResponsiveContainer>
+        </div>
+        <textarea readOnly value={code} style={{ width: '100%', height: '200px', marginTop: '1rem' }} />
+      </section>
+    )
+  }
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+
+      <ChartExample
+        title="Bar chart by plan"
+        description="Basic bar chart showing users per plan."
+        code={`<BarChart data={planData}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="name" />
+  <YAxis />
+  <Tooltip />
+  <Bar dataKey="value" fill="#8884d8" />
+</BarChart>`}
+      >
+        <BarChart data={planData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="value" fill="#8884d8" />
+        </BarChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Stacked bar chart"
+        description="Shows user status within each plan using stacked bars."
+        code={`<BarChart data={planStatusData}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="name" />
+  <YAxis />
+  <Tooltip />
+  <Legend />
+  <Bar dataKey="active" stackId="a" fill="#8884d8" />
+  <Bar dataKey="dormant" stackId="a" fill="#82ca9d" />
+  <Bar dataKey="blocked" stackId="a" fill="#ffc658" />
+</BarChart>`}
+      >
+        <BarChart data={planStatusData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="active" stackId="a" fill="#8884d8" />
+          <Bar dataKey="dormant" stackId="a" fill="#82ca9d" />
+          <Bar dataKey="blocked" stackId="a" fill="#ffc658" />
+        </BarChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Vertical bar chart"
+        description="Displays status counts with vertical layout."
+        code={`<BarChart data={statusData} layout="vertical" margin={{ left: 40 }}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis type="number" />
+  <YAxis dataKey="name" type="category" />
+  <Tooltip />
+  <Bar dataKey="value" fill="#82ca9d" />
+</BarChart>`}
+      >
+        <BarChart data={statusData} layout="vertical" margin={{ left: 40 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" />
+          <YAxis dataKey="name" type="category" />
+          <Tooltip />
+          <Bar dataKey="value" fill="#82ca9d" />
+        </BarChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Bar chart with brush"
+        description="Scrollable bar chart for top cities."
+        code={`<BarChart data={cityData}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="name" />
+  <YAxis />
+  <Tooltip />
+  <Bar dataKey="value" fill="#8884d8" />
+  <Brush dataKey="name" height={30} stroke="#8884d8" />
+</BarChart>`}
+      >
+        <BarChart data={cityData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="value" fill="#8884d8" />
+          <Brush dataKey="name" height={30} stroke="#8884d8" />
+        </BarChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Custom tooltip bar chart"
+        description="Bar chart of operating systems with custom tooltip."
+        code={`<BarChart data={osData}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="name" />
+  <YAxis />
+  <Tooltip content={({ payload }) => payload[0] && \`\${payload[0].name}: \${payload[0].value}\`} />
+  <Bar dataKey="value" fill="#ffc658" />
+</BarChart>`}
+      >
+        <BarChart data={osData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip content={({ payload }) => payload[0] && `${payload[0].name}: ${payload[0].value}`} />
+          <Bar dataKey="value" fill="#ffc658" />
+        </BarChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Line chart of signups"
+        description="Basic line chart of user signups by month."
+        code={`<LineChart data={signupByMonth}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Line type="linear" dataKey="value" stroke="#8884d8" />
+</LineChart>`}
+      >
+        <LineChart data={signupByMonth}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Line type="linear" dataKey="value" stroke="#8884d8" />
+        </LineChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Line chart without dots"
+        description="Active users per month with dots hidden."
+        code={`<LineChart data={activeByMonth}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Line type="linear" dataKey="value" stroke="#82ca9d" dot={false} />
+</LineChart>`}
+      >
+        <LineChart data={activeByMonth}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Line type="linear" dataKey="value" stroke="#82ca9d" dot={false} />
+        </LineChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Multi-line chart"
+        description="Compares signups and active users per month."
+        code={`<LineChart data={monthlyData}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Legend />
+  <Line type="monotone" dataKey="signups" stroke="#8884d8" />
+  <Line type="monotone" dataKey="active" stroke="#82ca9d" />
+</LineChart>`}
+      >
+        <LineChart data={monthlyData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Line type="monotone" dataKey="signups" stroke="#8884d8" />
+          <Line type="monotone" dataKey="active" stroke="#82ca9d" />
+        </LineChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Monotone line chart"
+        description="Active users with monotone curve."
+        code={`<LineChart data={activeByMonth}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Line type="monotone" dataKey="value" stroke="#ff7300" />
+</LineChart>`}
+      >
+        <LineChart data={activeByMonth}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#ff7300" />
+        </LineChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Area chart"
+        description="Area chart of signups per month."
+        code={`<AreaChart data={signupByMonth}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Area type="linear" dataKey="value" stroke="#8884d8" fill="#8884d8" />
+</AreaChart>`}
+      >
+        <AreaChart data={signupByMonth}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Area type="linear" dataKey="value" stroke="#8884d8" fill="#8884d8" />
+        </AreaChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Gradient area chart"
+        description="Active users per month with gradient fill."
+        code={`<AreaChart data={activeByMonth}>
+  <defs>
+    <linearGradient id="colorActive" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
+      <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
+    </linearGradient>
+  </defs>
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Area type="monotone" dataKey="value" stroke="#82ca9d" fill="url(#colorActive)" />
+</AreaChart>`}
+      >
+        <AreaChart data={activeByMonth}>
+          <defs>
+            <linearGradient id="colorActive" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Area type="monotone" dataKey="value" stroke="#82ca9d" fill="url(#colorActive)" />
+        </AreaChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Stacked area chart"
+        description="Stacked areas comparing signups and active users."
+        code={`<AreaChart data={monthlyData}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Area type="monotone" dataKey="signups" stackId="1" stroke="#8884d8" fill="#8884d8" />
+  <Area type="monotone" dataKey="active" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
+</AreaChart>`}
+      >
+        <AreaChart data={monthlyData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Area type="monotone" dataKey="signups" stackId="1" stroke="#8884d8" fill="#8884d8" />
+          <Area type="monotone" dataKey="active" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
+        </AreaChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Area chart with custom active dot"
+        description="Highlights points with a larger active dot."
+        code={`<AreaChart data={signupByMonth}>
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Area type="monotone" dataKey="value" stroke="#ff7300" fill="#ff7300" activeDot={{ r: 8 }} />
+</AreaChart>`}
+      >
+        <AreaChart data={signupByMonth}>
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Area type="monotone" dataKey="value" stroke="#ff7300" fill="#ff7300" activeDot={{ r: 8 }} />
+        </AreaChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Composed chart"
+        description="Combines bar and line in one chart."
+        code={`<ComposedChart data={monthlyData}>
+  <CartesianGrid strokeDasharray="3 3" />
+  <XAxis dataKey="month" />
+  <YAxis />
+  <Tooltip />
+  <Legend />
+  <Bar dataKey="signups" fill="#8884d8" />
+  <Line type="monotone" dataKey="active" stroke="#82ca9d" />
+</ComposedChart>`}
+      >
+        <ComposedChart data={monthlyData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="signups" fill="#8884d8" />
+          <Line type="monotone" dataKey="active" stroke="#82ca9d" />
+        </ComposedChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Pie chart"
+        description="Plan distribution as a pie chart."
+        code={`<PieChart>
+  <Pie data={planData} dataKey="value" nameKey="name" label>
+    {planData.map((entry, index) => (
+      <Cell key={entry.name} fill={colors[index % colors.length]} />
+    ))}
+  </Pie>
+  <Tooltip />
+</PieChart>`}
+      >
+        <PieChart>
+          <Pie data={planData} dataKey="value" nameKey="name" label>
+            {planData.map((entry, index) => (
+              <Cell key={entry.name} fill={colors[index % colors.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Donut pie chart"
+        description="Status distribution with inner radius."
+        code={`<PieChart>
+  <Pie data={statusData} dataKey="value" nameKey="name" innerRadius={60} outerRadius={80}>
+    {statusData.map((entry, index) => (
+      <Cell key={entry.name} fill={colors[index % colors.length]} />
+    ))}
+  </Pie>
+  <Tooltip />
+</PieChart>`}
+      >
+        <PieChart>
+          <Pie data={statusData} dataKey="value" nameKey="name" innerRadius={60} outerRadius={80}>
+            {statusData.map((entry, index) => (
+              <Cell key={entry.name} fill={colors[index % colors.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Radar chart"
+        description="Compares device usage across categories."
+        code={`<RadarChart data={deviceData} outerRadius={80}>
+  <PolarGrid />
+  <PolarAngleAxis dataKey="name" />
+  <PolarRadiusAxis />
+  <Radar dataKey="value" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
+</RadarChart>`}
+      >
+        <RadarChart data={deviceData} outerRadius={80}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="name" />
+          <PolarRadiusAxis />
+          <Radar dataKey="value" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
+        </RadarChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Radial bar chart"
+        description="Browser distribution with radial bars."
+        code={`<RadialBarChart innerRadius="20%" outerRadius="90%" data={browserData} startAngle={180} endAngle={0}>
+  <RadialBar background dataKey="value">
+    {browserData.map((entry, index) => (
+      <Cell key={entry.name} fill={colors[index % colors.length]} />
+    ))}
+  </RadialBar>
+  <Legend />
+</RadialBarChart>`}
+      >
+        <RadialBarChart innerRadius="20%" outerRadius="90%" data={browserData} startAngle={180} endAngle={0}>
+          <RadialBar background dataKey="value">
+            {browserData.map((entry, index) => (
+              <Cell key={entry.name} fill={colors[index % colors.length]} />
+            ))}
+          </RadialBar>
+          <Legend />
+        </RadialBarChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Scatter chart"
+        description="Days between signup and last active per user."
+        code={`<ScatterChart>
+  <CartesianGrid />
+  <XAxis dataKey="x" name="User ID" />
+  <YAxis dataKey="y" name="Active delay" />
+  <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+  <Scatter data={scatterData} fill="#8884d8" />
+</ScatterChart>`}
+      >
+        <ScatterChart>
+          <CartesianGrid />
+          <XAxis dataKey="x" name="User ID" />
+          <YAxis dataKey="y" name="Active delay" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <Scatter data={scatterData} fill="#8884d8" />
+        </ScatterChart>
+      </ChartExample>
+
+      <ChartExample
+        title="Treemap"
+        description="Treemap of users by city (top 10)."
+        code={`<Treemap data={cityData} dataKey="value" stroke="#fff" fill="#8884d8" />`}
+      >
+        <Treemap data={cityData} dataKey="value" stroke="#fff" fill="#8884d8" />
+      </ChartExample>
+    </div>
+  )
+}

--- a/src/admin/pages/adminDevPage.jsx
+++ b/src/admin/pages/adminDevPage.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+
+export default function AdminDevPage() {
+  const title = 'Admin Dev Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/admin/dev/charts/users` routes and link in admin sidebar
- show 20 user data visualizations via Recharts with code examples
- document new charts and bump version to 0.0.35

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b14a476ae4832e8d428217a670b21c