### PR TITLE
fix: flatten admin sidebar list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.37
+Current version: 0.0.38
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -11,7 +11,7 @@ Current version: 0.0.37
 - Admin pages have a separate collapsible menu
 - Code split between `src/user` and `src/admin`
 - Admin pages display "Subpages:" at the end with a full URL tree
-- Navigation sidebars derive from the same tree; admin lists all URLs, public lists non-admin URLs
+- Navigation sidebars derive from the same tree; admin lists all URLs flat (no nested lists), public lists non-admin URLs
 - Admin dev charts with 20 Recharts examples for users data
 
 # ACP+Charts сomming soon
@@ -116,7 +116,7 @@ _Only this section of the readme can be maintained using Russian language_
 
 # Verification steps
 1. Open several pages: /admin, /admin/section, /admin/section/subsection — confirm each shows "Subpages" at the bottom with the full tree.
-2. Check the admin left sidebar — all URLs present, nesting correct.
+2. Check the admin left sidebar — all URLs present and shown flat (no nested lists).
 3. Check the public site left sidebar — all URLs present except /admin and its descendants.
 4. After any page structure change, repeat steps 1–3.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.37",
+  "version": "0.0.38",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -971,6 +971,40 @@
           "scope": "readme"
         }
       ]
+    },
+    {
+      "version": "0.0.38",
+      "date": "2025-08-29",
+      "time": "13:29:44",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Flattened admin sidebar URL list to a single level",
+          "weight": 40,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Documented flat admin sidebar rule in README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Список URL админского сайдбара уплощён до одного уровня",
+          "weight": 40,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Задокументировано правило плоского списка админского сайдбара в README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ]
     }
   ],
   "releases": [
@@ -1830,6 +1864,40 @@
         },
         {
           "description": "Добавлено правило проверки навигации в README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ]
+    },
+    {
+      "version": "0.0.38",
+      "date": "2025-08-29",
+      "time": "13:29:44",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Flattened admin sidebar URL list to a single level",
+          "weight": 40,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Documented flat admin sidebar rule in README",
+          "weight": 20,
+          "type": "docs",
+          "scope": "readme"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Список URL админского сайдбара уплощён до одного уровня",
+          "weight": 40,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Задокументировано правило плоского списка админского сайдбара в README",
           "weight": 20,
           "type": "docs",
           "scope": "readme"

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -1,8 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { Sidebar, Home, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
 import urlTree from '../../urlTree.js'
 import './barLeftAdmin.css'
+
+const flattenTree = nodes =>
+  nodes.flatMap(n => [n.path, ...flattenTree(n.children)])
 
 export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = false }) {
   const [collapsed, setCollapsed] = useState(true)
@@ -44,16 +47,7 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
     if (collapsed) setHovered(false)
   }
 
-  const renderTree = nodes => (
-    <ul>
-      {nodes.map(n => (
-        <li key={n.path}>
-          <Link to={n.path}>{n.path}</Link>
-          {n.children.length > 0 && renderTree(n.children)}
-        </li>
-      ))}
-    </ul>
-  )
+  const flatUrls = useMemo(() => flattenTree(urlTree), [])
 
   return (
     <aside className={`sidebar-left ${isCollapsed ? 'collapsed' : ''}`} onMouseLeave={onMouseLeave}>
@@ -86,7 +80,17 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
           </>
         )}
       </div>
-      {!isCollapsed && <nav className="sidebar-content">{renderTree(urlTree)}</nav>}
+      {!isCollapsed && (
+        <nav className="sidebar-content">
+          <ul>
+            {flatUrls.map(path => (
+              <li key={path}>
+                <Link to={path}>{path}</Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
     </aside>
   )
 }


### PR DESCRIPTION
## Summary
- flatten admin sidebar URL tree into a single-level list
- document flat admin sidebar requirement
- record update in release notes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1567e0614832e8120175e1e10ef13