### PR TITLE
feat: restructure release notes headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.38
+Current version: 0.0.39
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -43,6 +43,7 @@ _Only this section of the readme can be maintained using Russian language_
   - - [x] 6.2.0 Реализовать базовый вывод релизов по времени.
   - - [ ] 6.2.1 Переключатель: релизы только по времени или релизы только по дням или кратчайшие релизы. Состояние переключателя при переключение сохранять в localstorage. (Создать /servises/localstorageHelper.jsx для лаконичного взаимодействия с localstorage.)
   - - [x] 6.2.2 Исправить отображение содержимого на /release-notes.
+  - - [x] 6.2.3 Настроить вывод даты в h2, версии и времени в h3 и добавить заметку о часовом поясе.
  - [x] 6.3 Добавить type и scope к записям release notes и вывести их на странице /release-notes.
  - [x] 6.4 Добавить правило для ботов в readme, что если есть вложенные страницы, то использовать специальный компонент для вывода подстраниц согласно схеме роутинга. Хранить этот компонент в отдельном файле.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.38",
+  "version": "0.0.39",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1005,6 +1005,28 @@
           "scope": "readme"
         }
       ]
+    },
+    {
+      "version": "0.0.39",
+      "date": "2025-08-29",
+      "time": "13:34:58",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Grouped releases by date and adjusted tags on release notes page",
+          "weight": 20,
+          "type": "feat",
+          "scope": "release-notes"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сгруппированы релизы по датам и обновлены теги на странице релизов",
+          "weight": 20,
+          "type": "feat",
+          "scope": "release-notes"
+        }
+      ]
     }
   ],
   "releases": [
@@ -1901,6 +1923,28 @@
           "weight": 20,
           "type": "docs",
           "scope": "readme"
+        }
+      ]
+    },
+    {
+      "version": "0.0.39",
+      "date": "2025-08-29",
+      "time": "13:34:58",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Grouped releases by date and adjusted tags on release notes page",
+          "weight": 20,
+          "type": "feat",
+          "scope": "release-notes"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сгруппированы релизы по датам и обновлены теги на странице релизов",
+          "weight": 20,
+          "type": "feat",
+          "scope": "release-notes"
         }
       ]
     }

--- a/src/user/pages/releaseNotesPage.css
+++ b/src/user/pages/releaseNotesPage.css
@@ -10,3 +10,8 @@
   text-shadow: 1px 1px 0 #333;
   padding: 2px 6px;
 }
+
+.tags-variant-21 span {
+  border: 1px solid #000;
+  padding: 2px 6px;
+}

--- a/src/user/pages/releaseNotesPage.jsx
+++ b/src/user/pages/releaseNotesPage.jsx
@@ -13,25 +13,41 @@ export default function ReleaseNotesPage() {
       (a, b) =>
         new Date(`${b.date}T${b.time}`) - new Date(`${a.date}T${a.time}`),
     )
+  const grouped = releases.reduce((acc, rel) => {
+    const group = acc.find(g => g.date === rel.date)
+    if (group) group.items.push(rel)
+    else acc.push({ date: rel.date, items: [rel] })
+    return acc
+  }, [])
   return (
     <div>
       <h1>{title}</h1>
-      {releases.map(rel => (
-        <div key={rel.version}>
-          <h2>
-            {rel.version} – {rel.date} {rel.time} {rel.timezone}
-          </h2>
-          <ul>
-            {rel.changes.map((ch, i) => (
-              <li key={i}>
-                {ch.description}
-                <div className="tags tags-variant-20">
-                  <span>{ch.type}</span>
-                  <span>{ch.scope}</span>
-                </div>
-              </li>
-            ))}
-          </ul>
+      <p>All times are shown in Asia/Bishkek time zone.</p>
+      {grouped.map(group => (
+        <div key={group.date}>
+          <h2>{group.date}</h2>
+          {group.items.map(rel => (
+            <div key={rel.version}>
+              <h3>
+                {rel.version} ({rel.time})
+              </h3>
+              <ul>
+                {rel.changes.map((ch, i) => (
+                  <li key={i}>
+                    {ch.description}
+                    <div className="tags">
+                      <div className="tags-variant-21">
+                        <span>{ch.type}</span>
+                      </div>
+                      <div className="tags-variant-20">
+                        <span>{ch.scope}</span>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Group releases by date and show versions with times on /release-notes
- Note Asia/Bishkek timezone and style scope/type tags with variants 20 and 21
- Bump version to 0.0.39 and log release

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b157c17ff8832e83e83bb232bb00b7