### PR TITLE
fix: hide empty subpages and restore recharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.42
+Current version: 0.0.43
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -10,7 +10,7 @@ Current version: 0.0.42
 - Public pages use a collapsible sidebar with icon tooltips and home link
 - Admin pages have a separate collapsible menu
 - Code split between `src/user` and `src/admin`
-- Admin pages display "Subpages:" at the end with a full URL tree
+- Admin pages display "Subpages:" with a full URL tree when subpages exist
 - Navigation sidebars derive from the same tree; admin lists all URLs flat (no nested lists), public lists non-admin URLs
 - Admin charts with 20 Recharts examples for users data
 
@@ -35,7 +35,8 @@ _Only this section of the readme can be maintained using Russian language_
 
 3. Графики
   - [x] 3.1 Создать страницы /admin/charts/users и /admin/charts/users/recharts с 20 вариантами графиков на Recharts. После каждого графика добавить описание и пример кода в textarea. Данные автоматически берутся из public/mocks/users.json.
-  - [ ] 3.2 Создать страницу /admin/charts/users/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из public/mocks/users.json.
+ - [ ] 3.2 Создать страницу /admin/charts/users/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из public/mocks/users.json.
+  - [x] 3.3 Исправить невидимые графики на /admin/charts/users/recharts.
 
 6. Удобства
  - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.
@@ -90,8 +91,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 # 14. Правки оформления
  - [x] 14.1 Изменить заголовок админских страниц на "| Admin Control Panel |"
- - [x] 14.2 Уменьшить глобальный размер h1 до 2.4em
+- [x] 14.2 Уменьшить глобальный размер h1 до 2.4em
 - [x] 14.3 Добавить префикс "Subpages:" перед списком подстраниц в /admin/*
+- [x] 14.4 Скрывать заголовок Subpages при отсутствии подстраниц.
 
 # 15. Маршруты
  - [x] 15.1 Удалить страницу /admin/charts и убрать сегмент dev из всех адресов админки.
@@ -115,7 +117,7 @@ _Only this section of the readme can be maintained using Russian language_
 12. If there is no indication what language the page should be in, use English.
 13. Update `release-notes.json` for every user-facing change according to `release-notes-howto.md`. Assign a weight between 20 and 80 and bump the PATCH version when cutting a release.
 14. Keep user and admin code separated in `/src/user` and `/src/admin`, each containing its own `app` and `pages` directories. Allow duplication between them but record every instance in the "Code duplication log" section.
-15. The admin layout automatically renders the `SubPages` component at the end of every `/admin` route; admin pages should not render `SubPages` themselves to avoid duplication, and each page ends with a "Subpages:" heading and links when available.
+15. The admin layout automatically renders the `SubPages` component at the end of every `/admin` route; admin pages should not render `SubPages` themselves to avoid duplication, and the component shows the "Subpages:" heading only when subpages exist.
 16. After each task, re-check navigation (see Verification steps).
 
 # Verification steps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.41",
+  "version": "0.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.41",
+      "version": "0.0.43",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.42",
+  "version": "0.0.43",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1105,6 +1105,40 @@
           "scope": "admin"
         }
       ]
+    },
+    {
+      "version": "0.0.43",
+      "date": "2025-08-29",
+      "time": "14:40:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Hid empty Subpages section in admin",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin"
+        },
+        {
+          "description": "Restored Recharts example visibility",
+          "weight": 40,
+          "type": "fix",
+          "scope": "charts"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Скрыт пустой блок Subpages в админке",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin"
+        },
+        {
+          "description": "Восстановлено отображение примеров Recharts",
+          "weight": 40,
+          "type": "fix",
+          "scope": "charts"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2101,6 +2135,40 @@
           "weight": 30,
           "type": "fix",
           "scope": "admin"
+        }
+      ]
+    },
+    {
+      "version": "0.0.43",
+      "date": "2025-08-29",
+      "time": "14:40:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Hid empty Subpages section in admin",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin"
+        },
+        {
+          "description": "Restored Recharts example visibility",
+          "weight": 40,
+          "type": "fix",
+          "scope": "charts"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Скрыт пустой блок Subpages в админке",
+          "weight": 30,
+          "type": "fix",
+          "scope": "admin"
+        },
+        {
+          "description": "Восстановлено отображение примеров Recharts",
+          "weight": 40,
+          "type": "fix",
+          "scope": "charts"
         }
       ]
     }

--- a/src/admin/app/subPages.jsx
+++ b/src/admin/app/subPages.jsx
@@ -27,10 +27,11 @@ export default function SubPages() {
   const { pathname } = useLocation()
   const node = findNode(pathname, urlTree)
   const children = node ? node.children : []
+  if (children.length === 0) return null
   return (
     <div style={{ marginTop: '2rem' }}>
       <h2>Subpages:</h2>
-      {children.length > 0 && renderTree(children)}
+      {renderTree(children)}
     </div>
   )
 }

--- a/src/admin/pages/adminChartsUsersRechartsPage.jsx
+++ b/src/admin/pages/adminChartsUsersRechartsPage.jsx
@@ -91,7 +91,7 @@ export default function AdminChartsUsersRechartsPage() {
         <h3>{title}</h3>
         <p>{description}</p>
         <div style={{ width: '100%', height: 300 }}>
-          <ResponsiveContainer>
+          <ResponsiveContainer width="100%" height="100%">
             {children}
           </ResponsiveContainer>
         </div>


### PR DESCRIPTION
## Summary
- hide Subpages block when page has no children
- fix Recharts examples by sizing ResponsiveContainer
- document behavior and bump version to 0.0.43

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15f6dd3a4832ea02663aaad148bd7