### PR TITLE
feat(admin): add collapsible headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.47
+Current version: 0.0.48
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -101,6 +101,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 # 15. Маршруты
  - [x] 15.1 Удалить страницу /admin/charts и убрать сегмент dev из всех адресов админки.
+
+16. Collapsible headings
+ - [x] 16.1 Enable collapsible headings in admin pages
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.46",
+  "version": "0.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.46",
+      "version": "0.0.48",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.47",
+  "version": "0.0.48",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1227,6 +1227,28 @@
           "scope": "charts"
         }
       ]
+    },
+    {
+      "version": "0.0.48",
+      "date": "2025-08-29",
+      "time": "16:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added collapsible admin headings",
+          "weight": 50,
+          "type": "feat",
+          "scope": "admin"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены сворачиваемые заголовки в админке",
+          "weight": 50,
+          "type": "feat",
+          "scope": "admin"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2345,6 +2367,28 @@
           "weight": 20,
           "type": "style",
           "scope": "charts"
+        }
+      ]
+    },
+    {
+      "version": "0.0.48",
+      "date": "2025-08-29",
+      "time": "16:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added collapsible admin headings",
+          "weight": 50,
+          "type": "feat",
+          "scope": "admin"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены сворачиваемые заголовки в админке",
+          "weight": 50,
+          "type": "feat",
+          "scope": "admin"
         }
       ]
     }

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -1,0 +1,130 @@
+import { useLayoutEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export default function useCollapsibleHeadings() {
+  const { pathname, search } = useLocation()
+
+  useLayoutEffect(() => {
+    const main = document.querySelector('main')
+    if (!main) return
+
+    const storageKey = `adminCollapse:${pathname}${search}`
+    let state = {}
+    try {
+      state = JSON.parse(localStorage.getItem(storageKey) || '{}')
+    } catch {
+      state = {}
+    }
+
+    let sections = []
+    let saveTimer
+
+    const saveState = () => {
+      clearTimeout(saveTimer)
+      saveTimer = setTimeout(() => {
+        localStorage.setItem(storageKey, JSON.stringify(state))
+      }, 100)
+    }
+
+    const cleanup = () => {
+      sections.forEach(({ button, section, handler, keyHandler }) => {
+        button.removeEventListener('click', handler)
+        button.removeEventListener('keydown', keyHandler)
+        button.remove()
+        while (section.firstChild) {
+          section.parentNode.insertBefore(section.firstChild, section)
+        }
+        section.remove()
+      })
+      sections = []
+      clearTimeout(saveTimer)
+    }
+
+    const build = () => {
+      cleanup()
+      const headings = Array.from(main.querySelectorAll('h2, h3, h4'))
+      headings.forEach((heading, index) => {
+        const level = Number(heading.tagName.slice(1))
+        const sectionId = `acph-sec-${index}`
+        let next = heading.nextElementSibling
+        const collected = []
+        while (
+          next &&
+          !(/H[2-4]/.test(next.tagName) && Number(next.tagName.slice(1)) <= level)
+        ) {
+          const temp = next.nextElementSibling
+          collected.push(next)
+          next = temp
+        }
+        const section = document.createElement('div')
+        section.id = sectionId
+        section.className = 'acph-section'
+        collected.forEach((el) => section.appendChild(el))
+        heading.after(section)
+
+        const button = document.createElement('button')
+        button.type = 'button'
+        button.className = 'acph-toggle'
+        button.setAttribute('role', 'button')
+        button.setAttribute('aria-controls', sectionId)
+        let collapsed = state[index] === '1'
+        button.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
+        button.textContent = collapsed ? '▶' : '▼'
+        if (collapsed) section.classList.add('is-collapsed')
+        heading.insertBefore(button, heading.firstChild)
+
+        const handler = () => {
+          collapsed = !collapsed
+          if (collapsed) {
+            section.classList.add('is-collapsed')
+            button.textContent = '▶'
+            button.setAttribute('aria-expanded', 'false')
+            state[index] = '1'
+          } else {
+            section.classList.remove('is-collapsed')
+            button.textContent = '▼'
+            button.setAttribute('aria-expanded', 'true')
+            state[index] = '0'
+          }
+          saveState()
+        }
+        const keyHandler = (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handler()
+          }
+        }
+        button.addEventListener('click', handler)
+        button.addEventListener('keydown', keyHandler)
+
+        sections.push({ button, section, handler, keyHandler })
+      })
+    }
+
+    build()
+
+    let observer
+    if (window.MutationObserver) {
+      observer = new MutationObserver((mutations) => {
+        if (
+          mutations.some((m) =>
+            Array.from(m.addedNodes).some(
+              (n) => n.querySelector && n.querySelector('h2, h3, h4')
+            )
+          )
+        ) {
+          observer.disconnect()
+          build()
+          observer.observe(main, { childList: true, subtree: true })
+        }
+      })
+      observer.observe(main, { childList: true, subtree: true })
+    }
+
+    return () => {
+      if (observer) observer.disconnect()
+      cleanup()
+    }
+  }, [pathname, search])
+}
+

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -7,3 +7,18 @@
   flex: 1;
   padding: 16px;
 }
+
+.acph-section {}
+
+.acph-section.is-collapsed {
+  display: none;
+}
+
+.acph-toggle {
+  cursor: pointer;
+  user-select: none;
+}
+
+.acph-toggle:focus {
+  outline: 2px solid currentColor;
+}

--- a/src/admin/app/layout.jsx
+++ b/src/admin/app/layout.jsx
@@ -1,5 +1,6 @@
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
+import useCollapsibleHeadings from './hooks/useCollapsibleHeadings.js'
 import BarLeftAdmin from './barLeftAdmin.jsx'
 import { isAdminAuth } from './auth.js'
 import SubPages from './subPages.jsx'
@@ -16,6 +17,8 @@ export default function Layout() {
       navigate('/admin/login', { replace: true })
     }
   }, [isLogin, navigate, location])
+
+  useCollapsibleHeadings()
 
   return (
     <div className="layout">


### PR DESCRIPTION
## Summary
- collapse admin page sections under h2–h4 with persistent state and dynamic rebinds
- wire hook into admin layout and style toggles for accessibility
- document feature, bump version to 0.0.48, and record release notes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2214f38f0832ea09fb9fd2a5426cb