### PR TITLE
docs: explain users mock keys for charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.48
+Current version: 0.0.49
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -37,9 +37,10 @@ _Only this section of the readme can be maintained using Russian language_
 
 3. Графики
   - [x] 3.1 Создать страницы /admin/charts/users и /admin/charts/users/recharts с 20 вариантами графиков на Recharts. После каждого графика добавить описание и пример кода в textarea. Данные автоматически берутся из public/mocks/users.json.
- - [ ] 3.2 Создать страницу /admin/charts/users/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из public/mocks/users.json.
+  - [ ] 3.2 Создать страницу /admin/charts/users/chartjs2 и вывести там 10 вариантов графиков bar/line/area и остальные при помощи Chart.js (react-chartjs-2). После каждого из них привести внутри просторной textarea пример кода для этого графика. Данные для графиков должны автоматически использоваться из public/mocks/users.json.
   - [x] 3.3 Исправить невидимые графики на /admin/charts/users/recharts.
   - [x] 3.4 Пронумеровать варианты графиков в заголовках на /admin/charts/users/recharts.
+  - [x] 3.5 Создать страницу /admin/charts/users/explain и описать ключи из users.json.
 
 6. Удобства
  - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.48",
+  "version": "0.0.49",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1249,6 +1249,28 @@
           "scope": "admin"
         }
       ]
+    },
+    {
+      "version": "0.0.49",
+      "date": "2025-08-29",
+      "time": "16:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added users data keys explanation page",
+          "weight": 30,
+          "type": "docs",
+          "scope": "charts"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена страница с пояснением ключей данных пользователей",
+          "weight": 30,
+          "type": "docs",
+          "scope": "charts"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2389,6 +2411,28 @@
           "weight": 50,
           "type": "feat",
           "scope": "admin"
+        }
+      ]
+    },
+    {
+      "version": "0.0.49",
+      "date": "2025-08-29",
+      "time": "16:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added users data keys explanation page",
+          "weight": 30,
+          "type": "docs",
+          "scope": "charts"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена страница с пояснением ключей данных пользователей",
+          "weight": 30,
+          "type": "docs",
+          "scope": "charts"
         }
       ]
     }

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -3,6 +3,7 @@ import AdminChartsPage from '../pages/adminChartsPage.jsx'
 import AdminChartsUsersPage from '../pages/adminChartsUsersPage.jsx'
 import AdminChartsUsersRechartsPage from '../pages/adminChartsUsersRechartsPage.jsx'
 import AdminChartsUsersChartjs2Page from '../pages/adminChartsUsersChartjs2Page.jsx'
+import AdminChartsUsersExplainPage from '../pages/adminChartsUsersExplainPage.jsx'
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
@@ -22,7 +23,8 @@ const adminRoutes = [
         label: 'Users',
         children: [
           { path: 'recharts', element: <AdminChartsUsersRechartsPage />, label: 'Recharts' },
-          { path: 'chartjs2', element: <AdminChartsUsersChartjs2Page />, label: 'Chartjs2' }
+          { path: 'chartjs2', element: <AdminChartsUsersChartjs2Page />, label: 'Chartjs2' },
+          { path: 'explain', element: <AdminChartsUsersExplainPage />, label: 'Explain' }
         ]
       }
     ]

--- a/src/admin/pages/adminChartsUsersExplainPage.jsx
+++ b/src/admin/pages/adminChartsUsersExplainPage.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+
+const keyInfo = {
+  id: {
+    app: 'Unique numeric identifier for a user account',
+    charts: 'Enables counting and deduplication of users'
+  },
+  name: {
+    app: 'Full name shown in profiles and communications',
+    charts: 'Occasionally used as a label in examples'
+  },
+  email: {
+    app: 'Login and contact address for the user',
+    charts: 'Allows grouping by domain for engagement metrics'
+  },
+  role: {
+    app: 'Defines permission level within the application',
+    charts: 'Segments charts by user roles'
+  },
+  plan: {
+    app: 'Subscription tier determining available features',
+    charts: 'Displays distribution of plan types'
+  },
+  status: {
+    app: 'Current account state such as active or blocked',
+    charts: 'Used to chart active vs dormant users'
+  },
+  createdAt: {
+    app: 'Date when the account was created',
+    charts: 'Feeds signup trend charts'
+  },
+  lastActiveAt: {
+    app: 'Last recorded activity date',
+    charts: 'Helps measure retention and churn'
+  },
+  country: {
+    app: 'Country for localization and compliance',
+    charts: 'Used for geographic distribution'
+  },
+  city: {
+    app: 'City for location-specific features',
+    charts: 'Allows city-level breakdowns'
+  },
+  device: {
+    app: 'Primary device type used by the user',
+    charts: 'Device usage shares'
+  },
+  os: {
+    app: 'Operating system of the user device',
+    charts: 'OS popularity charts'
+  },
+  browser: {
+    app: 'Web browser used for access',
+    charts: 'Browser usage statistics'
+  },
+  utmSource: {
+    app: 'Marketing source that led the user to sign up',
+    charts: 'Attribution performance comparisons'
+  },
+  emailVerifiedAt: {
+    app: 'Timestamp when email address was verified',
+    charts: 'Verification rate tracking'
+  },
+  churnedAt: {
+    app: 'Date when the user left the service, if applicable',
+    charts: 'Churn timing analysis'
+  }
+}
+
+export default function AdminChartsUsersExplainPage() {
+  const title = 'Admin Charts Users Explain Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [example, setExample] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+    fetch('/mocks/users.json')
+      .then(r => r.json())
+      .then(data => {
+        setExample(data[0])
+      })
+  }, [fullTitle])
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      {example && (
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Example</th>
+              <th>Application use</th>
+              <th>Charts use</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(example).map(([key, value]) => (
+              <tr key={key}>
+                <td>{key}</td>
+                <td>{String(value)}</td>
+                <td>{keyInfo[key]?.app || ''}</td>
+                <td>{keyInfo[key]?.charts || ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/src/urlTree.js
+++ b/src/urlTree.js
@@ -13,7 +13,8 @@ const urlTree = [
             path: '/admin/charts/users',
             children: [
               { path: '/admin/charts/users/recharts', children: [] },
-              { path: '/admin/charts/users/chartjs2', children: [] }
+              { path: '/admin/charts/users/chartjs2', children: [] },
+              { path: '/admin/charts/users/explain', children: [] }
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- add /admin/charts/users/explain with descriptions for every user data key
- wire page into admin routes and navigation tree
- document page in readme and release notes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b236dd4aa0832ebcc4686d0fad7bab