### PR TITLE
feat(admin-ui): add switch design variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ACP+Charts now
-Current version: 0.0.50
+Current version: 0.0.51
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
 - Admin login at `/admin/login` using env credentials
-- Admin access to dashboard, charts, and UI demos of 30 forms and 30 hashtags
+- Admin access to dashboard, charts, and UI demos of 30 forms, 30 hashtags, and 20 switches
 - Logout at `/admin/logout` with redirect for unauthenticated routes
 - Return to originally requested admin page after login
 - Public pages use a collapsible sidebar with icon tooltips and home link
@@ -86,6 +86,8 @@ _Only this section of the readme can be maintained using Russian language_
  - [x] 11.7 Добавить ещё 10 вариантов отображения хэштегов.
 
  - [x] 11.8 Сделать текущим вариантом формы №30.
+
+ - [x] 11.9 Добавить 20 вариантов переключателей.
 
 12. Code organization
  - [x] 12.1 Разделить код на /src/user и /src/admin с отдельными app и pages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.50",
+  "version": "0.0.51",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1293,6 +1293,28 @@
           "scope": "charts"
         }
       ]
+    },
+    {
+      "version": "0.0.51",
+      "date": "2025-08-29",
+      "time": "16:45:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added switch design variants to admin UI page",
+          "weight": 40,
+          "type": "feat",
+          "scope": "admin-ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены варианты дизайна переключателей на странице админского UI",
+          "weight": 40,
+          "type": "feat",
+          "scope": "admin-ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2477,6 +2499,28 @@
           "weight": 60,
           "type": "feat",
           "scope": "charts"
+        }
+      ]
+    },
+    {
+      "version": "0.0.51",
+      "date": "2025-08-29",
+      "time": "16:45:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added switch design variants to admin UI page",
+          "weight": 40,
+          "type": "feat",
+          "scope": "admin-ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены варианты дизайна переключателей на странице админского UI",
+          "weight": 40,
+          "type": "feat",
+          "scope": "admin-ui"
         }
       ]
     }

--- a/src/admin/pages/adminUiPage.css
+++ b/src/admin/pages/adminUiPage.css
@@ -313,3 +313,130 @@
 .tags-variant-30 {
   justify-content: flex-end;
 }
+
+.switch {
+  --switch-width: 40px;
+  --switch-height: 20px;
+  --switch-off-bg: #ccc;
+  --switch-on-bg: #4caf50;
+  --switch-knob-bg: #fff;
+  position: relative;
+  display: inline-block;
+  width: var(--switch-width);
+  height: var(--switch-height);
+  border-radius: var(--switch-radius, calc(var(--switch-height) / 2));
+  background: var(--switch-off-bg);
+  border: 1px solid #aaa;
+  cursor: pointer;
+  transition: background 0.2s;
+  padding: 0;
+}
+
+.switch::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: calc(var(--switch-height) - 2px);
+  height: calc(var(--switch-height) - 2px);
+  border-radius: var(--switch-knob-radius, 50%);
+  background: var(--switch-knob-bg);
+  transition: transform 0.2s;
+}
+
+.switch.on {
+  background: var(--switch-on-bg);
+}
+
+.switch.on::after {
+  transform: translateX(calc(var(--switch-width) - var(--switch-height)));
+}
+
+.switch-variant-1 {}
+
+.switch-variant-2 {
+  --switch-on-bg: #2196f3;
+}
+
+.switch-variant-3 {
+  --switch-on-bg: #f44336;
+}
+
+.switch-variant-4 {
+  --switch-on-bg: #9c27b0;
+}
+
+.switch-variant-5 {
+  --switch-on-bg: #ff9800;
+}
+
+.switch-variant-6 {
+  --switch-off-bg: #444;
+  --switch-on-bg: #0d6efd;
+  --switch-knob-bg: #fff;
+}
+
+.switch-variant-7 {
+  --switch-radius: 4px;
+  --switch-knob-radius: 2px;
+}
+
+.switch-variant-8 {
+  --switch-width: 60px;
+}
+
+.switch-variant-9 {
+  --switch-height: 26px;
+}
+
+.switch-variant-10 {
+  --switch-height: 14px;
+}
+
+.switch-variant-11 {
+  --switch-knob-bg: #000;
+}
+
+.switch-variant-12 {
+  --switch-knob-radius: 0;
+}
+
+.switch-variant-13 {
+  --switch-on-bg: linear-gradient(45deg, #ff9a9e, #fad0c4);
+}
+
+.switch-variant-14 {
+  border: 2px dashed #666;
+}
+
+.switch-variant-15 {
+  border: 2px solid #000;
+}
+
+.switch-variant-16 {
+  box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.5);
+}
+
+.switch-variant-17::after {
+  border: 1px solid #ccc;
+}
+
+.switch-variant-18 {
+  --switch-off-bg: #000;
+  --switch-on-bg: #0f0;
+  --switch-knob-bg: #fff;
+}
+
+.switch-variant-19 {
+  --switch-off-bg: transparent;
+  --switch-on-bg: #4caf50;
+  border: 1px solid #4caf50;
+}
+
+.switch-variant-20 {
+  --switch-on-bg: #333;
+}
+
+.switch-variant-20::after {
+  background: radial-gradient(circle, #fff 0%, #ccc 100%);
+}

--- a/src/admin/pages/adminUiPage.jsx
+++ b/src/admin/pages/adminUiPage.jsx
@@ -1,6 +1,18 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import AuthMessage from '../app/authMessage.jsx'
 import './adminUiPage.css'
+
+function SwitchDemo({ variant }) {
+  const [on, setOn] = useState(false)
+  return (
+    <button
+      type='button'
+      className={`switch switch-variant-${variant} ${on ? 'on' : ''}`}
+      onClick={() => setOn(!on)}
+      aria-label='toggle'
+    />
+  )
+}
 
 export default function AdminUiPage() {
   const title = 'UI | ACPC'
@@ -10,6 +22,7 @@ export default function AdminUiPage() {
 
   const loginVariants = Array.from({ length: 30 }, (_, i) => i + 1)
   const tagVariants = Array.from({ length: 30 }, (_, i) => i + 1)
+  const switchVariants = Array.from({ length: 20 }, (_, i) => i + 1)
   const loginChoice = 30
   const tagChoice = 20
   const tags = ['#alpha', '#beta', '#gamma']
@@ -48,6 +61,15 @@ export default function AdminUiPage() {
             ))}
           </div>
           {idx < tagVariants.length - 1 && <hr />}
+        </div>
+      ))}
+
+      <h2>Switch variants</h2>
+      {switchVariants.map((num, idx) => (
+        <div key={`switch-${num}`}>
+          <h3>{num}</h3>
+          <SwitchDemo variant={num} />
+          {idx < switchVariants.length - 1 && <hr />}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- add 20 toggle switch design examples to admin UI catalog
- document feature in README and release notes
- bump version to 0.0.51

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2717f0648832e9f20b2e42f790d12