### PR TITLE
feat: add metrics dashboard and charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # ACP+Charts now
-Current version: 0.0.51
+Current version: 0.0.52
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
 - Admin login at `/admin/login` using env credentials
 - Admin access to dashboard, charts, and UI demos of 30 forms and 30 hashtags
+- Metrics dashboard at `/admin/dashboard` with links to growth, engagement, reliability, and revenue charts
 - Logout at `/admin/logout` with redirect for unauthenticated routes
 - Return to originally requested admin page after login
 - Public pages use a collapsible sidebar with icon tooltips and home link
@@ -110,6 +111,10 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+
+18. Metrics dashboard
+ - [x] 18.1 Create `/admin/dashboard` with clickable mini charts
+ - [x] 18.2 Add growth, engagement, reliability, and revenue pages with client-side metrics
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1328,6 +1328,28 @@
         }
       ]
     }
+    ,{
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added metrics dashboard and graph pages",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлен дэшборд метрик и страницы графиков",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ]
+    }
   ],
   "releases": [
     {
@@ -2545,6 +2567,28 @@
           "weight": 30,
           "type": "refactor",
           "scope": "navigation"
+        }
+      ]
+    }
+    ,{
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added metrics dashboard and graph pages",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлен дэшборд метрик и страницы графиков",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
         }
       ]
     }

--- a/src/admin/app/hooks/metrics.js
+++ b/src/admin/app/hooks/metrics.js
@@ -1,0 +1,280 @@
+export function computeMetrics(activity, events, users) {
+  const days = activity.map(a => a.date).sort();
+  const activityMap = {};
+  activity.forEach(a => {
+    activityMap[a.date] = a;
+  });
+
+  const eventsByDate = {};
+  const firstEventDate = {};
+  events.forEach(ev => {
+    const date = ev.ts.slice(0, 10);
+    (eventsByDate[date] ||= []).push(ev);
+    if (ev.userId != null) {
+      if (!firstEventDate[ev.userId] || firstEventDate[ev.userId] > date) {
+        firstEventDate[ev.userId] = date;
+      }
+    }
+  });
+
+  const userSetsByDate = {};
+  Object.entries(eventsByDate).forEach(([date, evs]) => {
+    const set = new Set();
+    evs.forEach(ev => {
+      if (ev.userId != null) set.add(ev.userId);
+    });
+    userSetsByDate[date] = set;
+  });
+
+  const dau = {};
+  days.forEach(d => {
+    dau[d] = userSetsByDate[d] ? userSetsByDate[d].size : 0;
+  });
+
+  const wau = {};
+  const mau = {};
+  const datesSorted = [...days].sort();
+  for (let i = 0; i < datesSorted.length; i++) {
+    const d = datesSorted[i];
+    const w7 = new Set();
+    for (let j = Math.max(0, i - 6); j <= i; j++) {
+      userSetsByDate[datesSorted[j]]?.forEach(u => w7.add(u));
+    }
+    wau[d] = w7.size;
+    const w30 = new Set();
+    for (let j = Math.max(0, i - 29); j <= i; j++) {
+      userSetsByDate[datesSorted[j]]?.forEach(u => w30.add(u));
+    }
+    mau[d] = w30.size;
+  }
+
+  const dauArray = datesSorted.map(d => dau[d]);
+  function sma(arr, window) {
+    return arr.map((_, idx) => {
+      const start = Math.max(0, idx - window + 1);
+      const subset = arr.slice(start, idx + 1);
+      return subset.reduce((a, b) => a + b, 0) / subset.length;
+    });
+  }
+  const dauSMA7Array = sma(dauArray, 7);
+  const dauSMA7 = {};
+  datesSorted.forEach((d, idx) => {
+    dauSMA7[d] = dauSMA7Array[idx];
+  });
+
+  const newReturning = {};
+  datesSorted.forEach(d => {
+    const newSet = new Set();
+    (eventsByDate[d] || []).forEach(ev => {
+      if (ev.userId != null && firstEventDate[ev.userId] === d) newSet.add(ev.userId);
+    });
+    const newCount = newSet.size;
+    const dauVal = dau[d];
+    newReturning[d] = { new: newCount, returning: Math.max(dauVal - newCount, 0) };
+  });
+
+  const visitsSignupsLogins = datesSorted.map(d => ({
+    date: d,
+    visits: activityMap[d]?.visits || 0,
+    signups: activityMap[d]?.signups || 0,
+    logins: activityMap[d]?.logins || 0,
+  }));
+
+  const conversion = {};
+  const conversionDelta = {};
+  datesSorted.forEach(d => {
+    const a = activityMap[d];
+    const calc = a && a.visits ? a.signups / a.visits : 0;
+    conversion[d] = calc;
+    conversionDelta[d] = calc - (a?.conversion || 0);
+  });
+  const conversionArray = datesSorted.map(d => ({
+    date: d,
+    sessions: activityMap[d]?.sessions || 0,
+    conversion: conversion[d],
+    delta: conversionDelta[d],
+  }));
+
+  const stickiness = datesSorted.map(d => ({
+    date: d,
+    value: mau[d] > 0 ? dau[d] / mau[d] : 0,
+  }));
+
+  const errorRate = datesSorted.map(d => ({
+    date: d,
+    value: activityMap[d] && activityMap[d].sessions
+      ? activityMap[d].errors / activityMap[d].sessions
+      : 0,
+  }));
+
+  const errorsByCode = datesSorted.map(d => ({
+    date: d,
+    ...(activityMap[d]?.errorsByCode || {}),
+  }));
+
+  const totalErrorsByCode = {};
+  errorsByCode.forEach(day => {
+    Object.entries(day).forEach(([code, count]) => {
+      if (code !== 'date') totalErrorsByCode[code] = (totalErrorsByCode[code] || 0) + count;
+    });
+  });
+
+  const paretoErrors = Object.entries(totalErrorsByCode)
+    .sort((a, b) => b[1] - a[1])
+    .map(([code, count], idx, arr) => {
+      const total = arr.reduce((sum, [, c]) => sum + c, 0);
+      const cumulative = arr.slice(0, idx + 1).reduce((sum, [, c]) => sum + c, 0) / total;
+      return { code, count, cumulative };
+    });
+
+  const errorsByPageMap = {};
+  events.forEach(ev => {
+    if (ev.type === 'error') {
+      errorsByPageMap[ev.page] = (errorsByPageMap[ev.page] || 0) + 1;
+    }
+  });
+  const errorsByPage = Object.entries(errorsByPageMap)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([page, count]) => ({ page, count }));
+
+  const signupsSubscribes = datesSorted.map(d => ({
+    date: d,
+    signups: activityMap[d]?.signups || 0,
+    subscribes: 0,
+  }));
+  const subscribesPerDay = {};
+  events.forEach(ev => {
+    if (ev.type === 'subscribe') {
+      const d = ev.ts.slice(0, 10);
+      subscribesPerDay[d] = (subscribesPerDay[d] || 0) + 1;
+    }
+  });
+  signupsSubscribes.forEach(item => {
+    item.subscribes = subscribesPerDay[item.date] || 0;
+  });
+
+  const funnelSteps = ['visit', 'signup', 'verify', 'login', 'first_action', 'subscribe'];
+  const funnelCounts = {};
+  funnelSteps.forEach(s => (funnelCounts[s] = 0));
+  events.forEach(ev => {
+    if (funnelCounts[ev.type] != null) funnelCounts[ev.type]++;
+  });
+  const funnel = funnelSteps.map(name => ({ name, value: funnelCounts[name] }));
+
+  const userById = {};
+  users.forEach(u => {
+    userById[u.id] = u;
+  });
+  const segments = { plan: {}, utmSource: {}, country: {} };
+  events.forEach(ev => {
+    if (ev.type === 'subscribe') {
+      const u = userById[ev.userId];
+      if (!u) return;
+      segments.plan[u.plan] = (segments.plan[u.plan] || 0) + 1;
+      segments.utmSource[u.utmSource] = (segments.utmSource[u.utmSource] || 0) + 1;
+      segments.country[u.country] = (segments.country[u.country] || 0) + 1;
+    }
+  });
+  const segmentData = {
+    plan: Object.entries(segments.plan).map(([name, value]) => ({ name, value })),
+    utmSource: Object.entries(segments.utmSource).map(([name, value]) => ({ name, value })),
+    country: Object.entries(segments.country).map(([name, value]) => ({ name, value })),
+  };
+
+  function isoWeek(dateStr) {
+    const date = new Date(dateStr);
+    const tmp = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    tmp.setUTCDate(tmp.getUTCDate() + 4 - (tmp.getUTCDay() || 7));
+    const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
+    const weekNo = Math.ceil((((tmp - yearStart) / 86400000) + 1) / 7);
+    return `${tmp.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
+  }
+  const cohorts = {};
+  users.forEach(u => {
+    const cohort = isoWeek(u.createdAt);
+    if (!cohorts[cohort]) cohorts[cohort] = { total: 0, d7: 0, d14: 0, d28: 0 };
+    cohorts[cohort].total++;
+    const created = new Date(u.createdAt);
+    const last = new Date(u.lastActiveAt);
+    if (last - created >= 7 * 86400000) cohorts[cohort].d7++;
+    if (last - created >= 14 * 86400000) cohorts[cohort].d14++;
+    if (last - created >= 28 * 86400000) cohorts[cohort].d28++;
+  });
+  const cohortData = Object.entries(cohorts)
+    .map(([cohort, v]) => ({
+      cohort,
+      d7: v.total ? v.d7 / v.total : 0,
+      d14: v.total ? v.d14 / v.total : 0,
+      d28: v.total ? v.d28 / v.total : 0,
+    }))
+    .sort((a, b) => a.cohort.localeCompare(b.cohort));
+
+  function aggregate(arr, key) {
+    const res = {};
+    arr.forEach(u => {
+      res[u[key]] = (res[u[key]] || 0) + 1;
+    });
+    return Object.entries(res).map(([name, value]) => ({ name, value }));
+  }
+  const activeUsers = users.filter(u => u.status === 'active');
+  const deviceDist = aggregate(activeUsers, 'device');
+  const osDist = aggregate(activeUsers, 'os');
+  const browserDist = aggregate(activeUsers, 'browser');
+
+  const cumulative = [];
+  const sortedUsers = [...users].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  let count = 0;
+  let idx = 0;
+  datesSorted.forEach(d => {
+    while (idx < sortedUsers.length && sortedUsers[idx].createdAt <= d) {
+      count++;
+      idx++;
+    }
+    cumulative.push({ date: d, value: count });
+  });
+
+  const growth = datesSorted.map(d => ({
+    date: d,
+    dau: dau[d],
+    wau: wau[d],
+    mau: mau[d],
+    dauSMA7: dauSMA7[d],
+  }));
+
+  const newReturningArr = datesSorted.map(d => ({
+    date: d,
+    new: newReturning[d].new,
+    returning: newReturning[d].returning,
+  }));
+
+  return {
+    days: datesSorted,
+    growth,
+    newReturning: newReturningArr,
+    visitsSignupsLogins,
+    conversion: conversionArray,
+    stickiness,
+    cohortData,
+    deviceDist,
+    osDist,
+    browserDist,
+    errorRate,
+    errorsByCode,
+    paretoErrors,
+    errorsByPage,
+    signupsSubscribes,
+    funnel,
+    segmentData,
+    cumulative,
+  };
+}
+
+export default async function loadMetrics() {
+  const [a, e, u] = await Promise.all([
+    fetch('/mocks/activity.json').then(r => r.json()),
+    fetch('/mocks/events.json').then(r => r.json()),
+    fetch('/mocks/users.json').then(r => r.json()),
+  ]);
+  return computeMetrics(a, e, u);
+}

--- a/src/admin/app/hooks/useMetrics.js
+++ b/src/admin/app/hooks/useMetrics.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+import loadMetrics from './metrics.js'
+
+export default function useMetrics() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let mounted = true
+    loadMetrics()
+      .then(res => {
+        if (mounted) setData(res)
+      })
+      .catch(err => {
+        if (mounted) setError(err)
+      })
+      .finally(() => {
+        if (mounted) setLoading(false)
+      })
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  return { data, loading, error }
+}

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -7,11 +7,21 @@ import AdminChartsUsersExplainPage from '../pages/adminChartsUsersExplainPage.js
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+import AdminDashboardPage from '../pages/adminDashboardPage.jsx'
+import AdminGraphGrowthPage from '../pages/adminGraphGrowthPage.jsx'
+import AdminGraphEngagementPage from '../pages/adminGraphEngagementPage.jsx'
+import AdminGraphReliabilityPage from '../pages/adminGraphReliabilityPage.jsx'
+import AdminGraphRevenuePage from '../pages/adminGraphRevenuePage.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
   { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
   { index: true, element: <AdminPage />, label: 'Home' },
+  { path: 'dashboard', element: <AdminDashboardPage />, label: 'Dashboard' },
+  { path: 'graph/growth', element: <AdminGraphGrowthPage />, label: 'Growth' },
+  { path: 'graph/engagement', element: <AdminGraphEngagementPage />, label: 'Engagement' },
+  { path: 'graph/reliability', element: <AdminGraphReliabilityPage />, label: 'Reliability' },
+  { path: 'graph/revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' },
   {
     path: 'charts',
     element: <AdminChartsPage />,

--- a/src/admin/pages/adminDashboardPage.css
+++ b/src/admin/pages/adminDashboardPage.css
@@ -1,0 +1,25 @@
+.dash-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.dash-tile {
+  display: block;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.dash-tile h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+}
+
+.dash-mini-chart {
+  width: 100%;
+  height: 80px;
+}

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import AuthMessage from '../app/authMessage.jsx'
+import useMetrics from '../app/hooks/useMetrics.js'
+import { LineChart, Line, BarChart, Bar, ResponsiveContainer } from 'recharts'
+import './adminDashboardPage.css'
+
+function Tile({ title, link, children }) {
+  return (
+    <Link to={link} className="dash-tile">
+      <h3>{title}</h3>
+      <div className="dash-mini-chart">
+        {children}
+      </div>
+    </Link>
+  )
+}
+
+export default function AdminDashboardPage() {
+  const title = 'Admin Dashboard'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const { data, loading, error } = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (loading) return <div><h1>{fullTitle}</h1><AuthMessage /><p>Loading...</p></div>
+  if (error || !data) return <div><h1>{fullTitle}</h1><AuthMessage /><p>No data</p></div>
+
+  const { growth, conversion, errorRate, signupsSubscribes } = data
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <div className="dash-grid">
+        <Tile title="Growth" link="/admin/graph/growth">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={growth}>
+              <Line type="monotone" dataKey="dau" stroke="#8884d8" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </Tile>
+        <Tile title="Engagement" link="/admin/graph/engagement">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={conversion}>
+              <Line type="monotone" dataKey="conversion" stroke="#82ca9d" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </Tile>
+        <Tile title="Reliability" link="/admin/graph/reliability">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={errorRate}>
+              <Line type="monotone" dataKey="value" stroke="#ff7300" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </Tile>
+        <Tile title="Revenue" link="/admin/graph/revenue">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={signupsSubscribes}>
+              <Bar dataKey="subscribes" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        </Tile>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+import useMetrics from '../app/hooks/useMetrics.js'
+import {
+  ComposedChart, Bar, Line, XAxis, YAxis, Tooltip, CartesianGrid,
+  ResponsiveContainer, LineChart, ReferenceLine, Legend, BarChart
+} from 'recharts'
+
+export default function AdminGraphEngagementPage() {
+  const title = 'Engagement Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const { data, loading, error } = useMetrics()
+  const [segment, setSegment] = useState('device')
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (loading) return <div><h1>{fullTitle}</h1><AuthMessage /><p>Loading...</p></div>
+  if (error || !data) return <div><h1>{fullTitle}</h1><AuthMessage /><p>No data</p></div>
+
+  const { conversion, stickiness, cohortData, deviceDist, osDist, browserDist } = data
+  const segmentMap = { device: deviceDist, os: osDist, browser: browserDist }
+  const segmentData = segmentMap[segment]
+  const stackData = [segmentData.reduce((acc, cur) => ({ ...acc, [cur.name]: cur.value }), {})]
+  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#8dd1e1', '#a4de6c']
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <ComposedChart data={conversion}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis yAxisId="left" />
+            <YAxis yAxisId="right" orientation="right" tickFormatter={v => `${(v * 100).toFixed(0)}%`} />
+            <Tooltip formatter={(v, n) => n === 'conversion' ? `${(v * 100).toFixed(1)}%` : v} />
+            <Bar yAxisId="left" dataKey="sessions" fill="#8884d8" />
+            <Line yAxisId="right" type="monotone" dataKey="conversion" stroke="#ff7300" />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <LineChart data={stickiness}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis tickFormatter={v => `${(v * 100).toFixed(0)}%`} />
+            <Tooltip formatter={v => `${(v * 100).toFixed(1)}%`} />
+            <ReferenceLine y={0.3} stroke="red" strokeDasharray="3 3" />
+            <ReferenceLine y={0.5} stroke="green" strokeDasharray="3 3" />
+            <Line type="monotone" dataKey="value" stroke="#82ca9d" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <BarChart data={cohortData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="cohort" />
+            <YAxis tickFormatter={v => `${(v * 100).toFixed(0)}%`} />
+            <Tooltip formatter={v => `${(v * 100).toFixed(1)}%`} />
+            <Legend />
+            <Bar dataKey="d7" stackId="a" fill="#8884d8" />
+            <Bar dataKey="d14" stackId="a" fill="#82ca9d" />
+            <Bar dataKey="d28" stackId="a" fill="#ffc658" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <button onClick={() => setSegment('device')}>Device</button>
+          <button onClick={() => setSegment('os')}>OS</button>
+          <button onClick={() => setSegment('browser')}>Browser</button>
+        </div>
+        <ResponsiveContainer>
+          <BarChart data={stackData}>
+            <XAxis hide dataKey="name" />
+            <YAxis hide />
+            <Tooltip />
+            {segmentData.map((d, i) => (
+              <Bar key={d.name} dataKey={d.name} stackId="a" fill={colors[i % colors.length]} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+import useMetrics from '../app/hooks/useMetrics.js'
+import {
+  AreaChart, Area, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer
+} from 'recharts'
+
+export default function AdminGraphGrowthPage() {
+  const title = 'Growth Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const { data, loading, error } = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (loading) return <div><h1>{fullTitle}</h1><AuthMessage /><p>Loading...</p></div>
+  if (error || !data) return <div><h1>{fullTitle}</h1><AuthMessage /><p>No data</p></div>
+
+  const { growth, newReturning, visitsSignupsLogins } = data
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <AreaChart data={growth}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Area type="monotone" dataKey="dau" stackId="1" stroke="#8884d8" fill="#8884d8" />
+            <Area type="monotone" dataKey="wau" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
+            <Area type="monotone" dataKey="mau" stackId="1" stroke="#ffc658" fill="#ffc658" />
+            <Line type="monotone" dataKey="dauSMA7" stroke="#ff7300" dot={false} />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <AreaChart data={newReturning}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Area type="monotone" dataKey="new" stackId="1" stroke="#8884d8" fill="#8884d8" />
+            <Area type="monotone" dataKey="returning" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <LineChart data={visitsSignupsLogins}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="visits" stroke="#8884d8" />
+            <Line type="monotone" dataKey="signups" stroke="#82ca9d" />
+            <Line type="monotone" dataKey="logins" stroke="#ffc658" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -1,0 +1,80 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+import useMetrics from '../app/hooks/useMetrics.js'
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer,
+  AreaChart, Area, ComposedChart, Bar, ReferenceLine, Legend
+} from 'recharts'
+
+export default function AdminGraphReliabilityPage() {
+  const title = 'Reliability Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const { data, loading, error } = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (loading) return <div><h1>{fullTitle}</h1><AuthMessage /><p>Loading...</p></div>
+  if (error || !data) return <div><h1>{fullTitle}</h1><AuthMessage /><p>No data</p></div>
+
+  const { errorRate, errorsByCode, paretoErrors } = data
+  const codes = Object.keys(errorsByCode[0] || {}).filter(k => k !== 'date')
+  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#8dd1e1', '#a4de6c']
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <LineChart data={errorRate}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis tickFormatter={v => `${(v * 100).toFixed(2)}%`} />
+            <Tooltip formatter={v => `${(v * 100).toFixed(2)}%`} />
+            <ReferenceLine y={0.02} stroke="red" />
+            <Line type="monotone" dataKey="value" stroke="#8884d8" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <AreaChart data={errorsByCode}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            {codes.map((c, i) => (
+              <Area
+                key={c}
+                type="monotone"
+                dataKey={c}
+                stackId="1"
+                stroke={colors[i % colors.length]}
+                fill={colors[i % colors.length]}
+              />
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <ComposedChart data={paretoErrors}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="code" />
+            <YAxis yAxisId="left" />
+            <YAxis yAxisId="right" orientation="right" tickFormatter={v => `${(v * 100).toFixed(0)}%`} />
+            <Tooltip formatter={(v, n) => n === 'cumulative' ? `${(v * 100).toFixed(1)}%` : v} />
+            <Bar yAxisId="left" dataKey="count" fill="#8884d8" />
+            <Line yAxisId="right" type="monotone" dataKey="cumulative" stroke="#ff7300" />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+import useMetrics from '../app/hooks/useMetrics.js'
+import {
+  ComposedChart, Bar, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer,
+  FunnelChart, Funnel, LabelList, LineChart
+} from 'recharts'
+
+export default function AdminGraphRevenuePage() {
+  const title = 'Revenue Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const { data, loading, error } = useMetrics()
+  const [segment, setSegment] = useState('plan')
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (loading) return <div><h1>{fullTitle}</h1><AuthMessage /><p>Loading...</p></div>
+  if (error || !data) return <div><h1>{fullTitle}</h1><AuthMessage /><p>No data</p></div>
+
+  const { funnel, segmentData, signupsSubscribes, cumulative } = data
+  const seg = segmentData[segment]
+  const stackData = [seg.reduce((acc, cur) => ({ ...acc, [cur.name]: cur.value }), {})]
+  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#8dd1e1', '#a4de6c']
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <FunnelChart>
+            <Tooltip />
+            <Funnel dataKey="value" data={funnel} fill="#8884d8">
+              <LabelList position="right" dataKey="name" />
+            </Funnel>
+          </FunnelChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <ComposedChart data={signupsSubscribes}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="signups" fill="#8884d8" />
+            <Line type="monotone" dataKey="subscribes" stroke="#ff7300" />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <LineChart width={600} height={300} data={cumulative}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#82ca9d" />
+        </LineChart>
+      </div>
+
+      <div style={{ width: '100%', height: 300 }}>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <button onClick={() => setSegment('plan')}>Plan</button>
+          <button onClick={() => setSegment('utmSource')}>UTM</button>
+          <button onClick={() => setSegment('country')}>Country</button>
+        </div>
+        <ResponsiveContainer>
+          <BarChart data={stackData} layout="vertical" stackOffset="expand">
+            <XAxis type="number" hide />
+            <YAxis type="category" dataKey="name" hide />
+            <Tooltip formatter={(v) => `${(v * 100).toFixed(1)}%`} />
+            {seg.map((d, i) => (
+              <Bar key={d.name} dataKey={d.name} stackId="a" fill={colors[i % colors.length]} barSize={20} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/src/urlTree.json
+++ b/src/urlTree.json
@@ -22,7 +22,12 @@
           }
         ]
       },
-      { "path": "/admin/ui", "name": "UI", "children": [] }
+      { "path": "/admin/ui", "name": "UI", "children": [] },
+      { "path": "/admin/dashboard", "name": "Dashboard", "children": [] },
+      { "path": "/admin/graph/growth", "name": "Growth", "children": [] },
+      { "path": "/admin/graph/engagement", "name": "Engagement", "children": [] },
+      { "path": "/admin/graph/reliability", "name": "Reliability", "children": [] },
+      { "path": "/admin/graph/revenue", "name": "Revenue", "children": [] }
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- add client-side metrics calculations for growth, engagement, reliability, and revenue
- build admin dashboard with mini charts linking to detailed metric pages
- document new routes and bump version to 0.0.52

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b27cb42650832e99059efc629c8fde