### PR TITLE
feat: add analytics dashboard and graph pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.51
+Current version: 0.0.52
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -15,6 +15,7 @@ Current version: 0.0.51
 - User and admin sidebars highlight the active link
 - Admin charts with 20 Recharts examples for users data
 - Admin charts with 21 Chart.js examples for users data
+- Admin dashboard with mini metrics and navigation to growth, engagement, reliability, and revenue graphs powered by Chart.js
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -110,6 +111,10 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+
+18. Analytics dashboard
+  - [x] 18.1 Add /admin/dashboard with mini charts
+  - [x] 18.2 Add graph pages for growth, engagement, reliability, revenue
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1327,6 +1327,28 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Introduced admin dashboard and analytics graph pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена админская панель и страницы аналитики",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2545,6 +2567,28 @@
           "weight": 30,
           "type": "refactor",
           "scope": "navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Introduced admin dashboard and analytics graph pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена админская панель и страницы аналитики",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
         }
       ]
     }

--- a/src/admin/app/chartSetup.js
+++ b/src/admin/app/chartSetup.js
@@ -1,0 +1,6 @@
+import { Chart as ChartJS, registerables } from 'chart.js'
+
+ChartJS.register(...registerables)
+
+export default ChartJS
+

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -7,10 +7,17 @@ import AdminChartsUsersExplainPage from '../pages/adminChartsUsersExplainPage.js
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+import AdminDashboardPage from '../pages/adminDashboardPage.jsx'
+import AdminGraphPage from '../pages/adminGraphPage.jsx'
+import AdminGraphGrowthPage from '../pages/adminGraphGrowthPage.jsx'
+import AdminGraphEngagementPage from '../pages/adminGraphEngagementPage.jsx'
+import AdminGraphReliabilityPage from '../pages/adminGraphReliabilityPage.jsx'
+import AdminGraphRevenuePage from '../pages/adminGraphRevenuePage.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
   { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
+  { path: 'dashboard', element: <AdminDashboardPage />, label: 'Dashboard' },
   { index: true, element: <AdminPage />, label: 'Home' },
   {
     path: 'charts',
@@ -27,6 +34,17 @@ const adminRoutes = [
           { path: 'explain', element: <AdminChartsUsersExplainPage />, label: 'Explain' }
         ]
       }
+    ]
+  },
+  {
+    path: 'graph',
+    element: <AdminGraphPage />,
+    label: 'Graph',
+    children: [
+      { path: 'growth', element: <AdminGraphGrowthPage />, label: 'Growth' },
+      { path: 'engagement', element: <AdminGraphEngagementPage />, label: 'Engagement' },
+      { path: 'reliability', element: <AdminGraphReliabilityPage />, label: 'Reliability' },
+      { path: 'revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' }
     ]
   },
   { path: 'ui', element: <AdminUiPage />, label: 'UI' },

--- a/src/admin/data/analytics.js
+++ b/src/admin/data/analytics.js
@@ -1,0 +1,267 @@
+export async function loadAll() {
+  const [events, activity, users] = await Promise.all([
+    fetch('/mocks/events.json').then(r => r.json()),
+    fetch('/mocks/activity.json').then(r => r.json()),
+    fetch('/mocks/users.json').then(r => r.json())
+  ])
+  return { events, activity, users }
+}
+
+export function dateRange(start, end) {
+  const dates = []
+  const d = new Date(start)
+  const endDate = new Date(end)
+  while (d <= endDate) {
+    dates.push(d.toISOString().slice(0, 10))
+    d.setUTCDate(d.getUTCDate() + 1)
+  }
+  return dates
+}
+
+export function groupEventsByDate(events) {
+  const map = {}
+  const firstSeen = {}
+  events.forEach(e => {
+    const date = e.ts.slice(0, 10)
+    if (!map[date]) map[date] = { userIds: new Set(), types: {}, errorsByPage: {} }
+    map[date].userIds.add(e.userId)
+    map[date].types[e.type] = (map[date].types[e.type] || 0) + 1
+    if (e.type === 'error') {
+      map[date].errorsByPage[e.page] = (map[date].errorsByPage[e.page] || 0) + 1
+    }
+    if (!firstSeen[e.userId] || firstSeen[e.userId] > date) firstSeen[e.userId] = date
+  })
+  return { map, firstSeen }
+}
+
+export function computeDAU(dates, eventMap) {
+  return dates.map(d => (eventMap[d] ? eventMap[d].userIds.size : 0))
+}
+
+export function computeWindowAU(dates, eventMap, window) {
+  const result = []
+  for (let i = 0; i < dates.length; i++) {
+    const start = Math.max(0, i - window + 1)
+    const users = new Set()
+    for (let j = start; j <= i; j++) {
+      const d = dates[j]
+      if (eventMap[d]) eventMap[d].userIds.forEach(u => users.add(u))
+    }
+    result.push(users.size)
+  }
+  return result
+}
+
+export function computeSMA(values, window) {
+  const res = []
+  for (let i = 0; i < values.length; i++) {
+    const start = Math.max(0, i - window + 1)
+    let sum = 0
+    let count = 0
+    for (let j = start; j <= i; j++) {
+      sum += values[j]
+      count++
+    }
+    res.push(count > 0 ? sum / count : 0)
+  }
+  return res
+}
+
+export function computeNewReturning(dates, events, firstSeen) {
+  const map = {}
+  events.forEach(e => {
+    const date = e.ts.slice(0, 10)
+    if (!map[date]) map[date] = { new: new Set(), returning: new Set() }
+    if (firstSeen[e.userId] === date) map[date].new.add(e.userId)
+    else map[date].returning.add(e.userId)
+  })
+  return dates.map(d => ({
+    new: map[d] ? map[d].new.size : 0,
+    returning: map[d] ? map[d].returning.size : 0
+  }))
+}
+
+export function loginsByWeekday(events) {
+  const counts = Array(7).fill(0)
+  events.forEach(e => {
+    if (e.type === 'login') {
+      const day = new Date(e.ts).getUTCDay() // 0 Sun
+      const idx = (day + 6) % 7 // 0 Mon
+      counts[idx]++
+    }
+  })
+  return counts
+}
+
+export function subsPerDay(dates, eventMap) {
+  return dates.map(d => (eventMap[d] ? eventMap[d].types.subscribe || 0 : 0))
+}
+
+export function funnelTotals(eventMap) {
+  const totals = { visit: 0, signup: 0, verify: 0, login: 0, first_action: 0, subscribe: 0 }
+  Object.values(eventMap).forEach(day => {
+    Object.keys(totals).forEach(t => {
+      totals[t] += day.types[t] || 0
+    })
+  })
+  return totals
+}
+
+export function errorEventsByPage(eventMap) {
+  const pageCounts = {}
+  Object.values(eventMap).forEach(day => {
+    Object.entries(day.errorsByPage).forEach(([page, count]) => {
+      pageCounts[page] = (pageCounts[page] || 0) + count
+    })
+  })
+  return Object.entries(pageCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+}
+
+export function activityMapByDate(activity) {
+  const map = {}
+  activity.forEach(a => {
+    map[a.date] = a
+  })
+  return map
+}
+
+export function conversionCalc(dates, activityMap) {
+  return dates.map(d => {
+    const a = activityMap[d]
+    return a && a.visits > 0 ? a.signups / a.visits : 0
+  })
+}
+
+export function errorRate(dates, activityMap) {
+  return dates.map(d => {
+    const a = activityMap[d]
+    return a && a.sessions > 0 ? a.errors / a.sessions : 0
+  })
+}
+
+export function sessionsPerDay(dates, activityMap) {
+  return dates.map(d => (activityMap[d] ? activityMap[d].sessions : 0))
+}
+
+export function signupsPerDay(dates, activityMap) {
+  return dates.map(d => (activityMap[d] ? activityMap[d].signups : 0))
+}
+
+export function visitsPerDay(dates, activityMap) {
+  return dates.map(d => (activityMap[d] ? activityMap[d].visits : 0))
+}
+
+export function loginsPerDay(dates, activityMap) {
+  return dates.map(d => (activityMap[d] ? activityMap[d].logins : 0))
+}
+
+export function errorsByCodePerDay(dates, activityMap) {
+  const codes = {}
+  dates.forEach(d => {
+    const a = activityMap[d]
+    if (a && a.errorsByCode) {
+      Object.keys(a.errorsByCode).forEach(code => {
+        if (!codes[code]) codes[code] = []
+      })
+    }
+  })
+  const codeNames = Object.keys(codes)
+  codeNames.forEach(code => {
+    codes[code] = dates.map(d => (activityMap[d] && activityMap[d].errorsByCode ? activityMap[d].errorsByCode[code] || 0 : 0))
+  })
+  return { codes: codeNames, data: codes }
+}
+
+export function errorTotalsByCode(activity) {
+  const totals = {}
+  activity.forEach(a => {
+    Object.entries(a.errorsByCode || {}).forEach(([code, count]) => {
+      totals[code] = (totals[code] || 0) + count
+    })
+  })
+  const entries = Object.entries(totals).sort((a, b) => b[1] - a[1])
+  let cumulative = 0
+  const totalErrors = entries.reduce((s, [, c]) => s + c, 0)
+  const cumPct = entries.map(([code, count]) => {
+    cumulative += count
+    return { code, count, pct: (cumulative / totalErrors) * 100 }
+  })
+  return { entries, cumPct }
+}
+
+export function retentionCohorts(users) {
+  const cohorts = {}
+  users.forEach(u => {
+    const created = u.createdAt
+    const week = weekKey(created)
+    if (!cohorts[week]) cohorts[week] = { total: 0, d7: 0, d14: 0, d28: 0 }
+    cohorts[week].total++
+    const createdDate = new Date(created)
+    const last = new Date(u.lastActiveAt)
+    if (last - createdDate >= 7 * 86400000) cohorts[week].d7++
+    if (last - createdDate >= 14 * 86400000) cohorts[week].d14++
+    if (last - createdDate >= 28 * 86400000) cohorts[week].d28++
+  })
+  const weeks = Object.keys(cohorts).sort()
+  const data = weeks.map(w => cohorts[w])
+  return { weeks, data }
+}
+
+function weekKey(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00Z')
+  const day = d.getUTCDay() || 7
+  d.setUTCDate(d.getUTCDate() + 4 - day)
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1))
+  const weekNo = Math.ceil(((d - yearStart) / 86400000 + 1) / 7)
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`
+}
+
+export function platformDistribution(users) {
+  const dims = {
+    device: {},
+    os: {},
+    browser: {}
+  }
+  users.forEach(u => {
+    dims.device[u.device] = (dims.device[u.device] || 0) + 1
+    dims.os[u.os] = (dims.os[u.os] || 0) + 1
+    dims.browser[u.browser] = (dims.browser[u.browser] || 0) + 1
+  })
+  return dims
+}
+
+export function subscriptionSegments(events, users) {
+  const userMap = {}
+  users.forEach(u => (userMap[u.id] = u))
+  const seg = { plan: {}, utmSource: {}, country: {} }
+  events.forEach(e => {
+    if (e.type === 'subscribe') {
+      const u = userMap[e.userId]
+      if (!u) return
+      seg.plan[u.plan] = (seg.plan[u.plan] || 0) + 1
+      seg.utmSource[u.utmSource] = (seg.utmSource[u.utmSource] || 0) + 1
+      seg.country[u.country] = (seg.country[u.country] || 0) + 1
+    }
+  })
+  return seg
+}
+
+export function cumulativeUsers(users) {
+  const dates = users.map(u => u.createdAt).sort()
+  const start = dates[0]
+  const end = dates[dates.length - 1]
+  const range = dateRange(start, end)
+  const counts = {}
+  users.forEach(u => {
+    counts[u.createdAt] = (counts[u.createdAt] || 0) + 1
+  })
+  let total = 0
+  const cum = range.map(d => {
+    total += counts[d] || 0
+    return total
+  })
+  return { dates: range, values: cum }
+}
+

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import {
+  loadAll,
+  groupEventsByDate,
+  activityMapByDate,
+  dateRange,
+  computeDAU,
+  conversionCalc,
+  errorRate,
+  subsPerDay
+} from '../data/analytics.js'
+
+export default function AdminDashboardPage() {
+  const title = 'Admin Dashboard'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    loadAll().then(setData)
+  }, [])
+
+  const { dates, dau, conv, errRate, subs, period } = useMemo(() => {
+    if (!data) return {}
+    const { events, activity } = data
+    const { map: eventMap } = groupEventsByDate(events)
+    const activityMap = activityMapByDate(activity)
+    const start = Math.min(
+      ...[Object.keys(eventMap)[0], activity[0].date].map(d => new Date(d))
+    )
+    const end = Math.max(
+      ...[Object.keys(eventMap).slice(-1)[0], activity[activity.length - 1].date].map(d => new Date(d))
+    )
+    const startStr = new Date(start).toISOString().slice(0, 10)
+    const endStr = new Date(end).toISOString().slice(0, 10)
+    const range = dateRange(startStr, endStr)
+    return {
+      dates: range,
+      dau: computeDAU(range, eventMap),
+      conv: conversionCalc(range, activityMap),
+      errRate: errorRate(range, activityMap),
+      subs: subsPerDay(range, eventMap),
+      period: `${startStr} to ${endStr}`
+    }
+  }, [data])
+
+  if (!data) return <p>Loading...</p>
+
+  const baseOptions = { plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }
+
+  return (
+    <div>
+      <h1>{title}</h1>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px,1fr))', gap: '1rem' }}>
+        <Link to="/admin/graph/growth" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Line data={{ labels: dates, datasets: [{ data: dau, borderColor: '#8884d8', tension: 0 }] }} options={baseOptions} />
+          <p>Source: events.json, Formula: distinct userId per day, Period: {period}</p>
+        </Link>
+        <Link to="/admin/graph/engagement" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Line data={{ labels: dates, datasets: [{ data: conv, borderColor: '#82ca9d', tension: 0 }] }} options={baseOptions} />
+          <p>Source: activity.json, Formula: signups/visits, Period: {period}</p>
+        </Link>
+        <Link to="/admin/graph/reliability" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Line data={{ labels: dates, datasets: [{ data: errRate, borderColor: '#ff7300', tension: 0 }] }} options={baseOptions} />
+          <p>Source: activity.json, Formula: errors/sessions, Period: {period}</p>
+        </Link>
+        <Link to="/admin/graph/revenue" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Bar data={{ labels: dates, datasets: [{ data: subs, backgroundColor: '#413ea0' }] }} options={baseOptions} />
+          <p>Source: events.json, Formula: count subscribe events per day, Period: {period}</p>
+        </Link>
+      </div>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Bar, Line } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import {
+  loadAll,
+  groupEventsByDate,
+  activityMapByDate,
+  dateRange,
+  computeDAU,
+  computeWindowAU,
+  conversionCalc,
+  sessionsPerDay,
+  retentionCohorts,
+  platformDistribution
+} from '../data/analytics.js'
+
+export default function AdminGraphEngagementPage() {
+  const title = 'Engagement Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    loadAll().then(setData)
+  }, [])
+
+  const metrics = useMemo(() => {
+    if (!data) return null
+    const { events, activity, users } = data
+    const { map: eventMap } = groupEventsByDate(events)
+    const activityMap = activityMapByDate(activity)
+    const dates = dateRange(activity[0].date, activity[activity.length - 1].date)
+    const dau = computeDAU(dates, eventMap)
+    const mau = computeWindowAU(dates, eventMap, 30)
+    const stickiness = dau.map((v, i) => (mau[i] ? v / mau[i] : 0))
+    const conv = conversionCalc(dates, activityMap)
+    const sessions = sessionsPerDay(dates, activityMap)
+    const cohorts = retentionCohorts(users)
+    const platforms = platformDistribution(users)
+    return { dates, stickiness, conv, sessions, cohorts, platforms, period: `${dates[0]} to ${dates[dates.length-1]}` }
+  }, [data])
+
+  if (!metrics) return <p>Loading...</p>
+
+  const cohortDatasets = ['d7', 'd14', 'd28'].map((k, idx) => ({
+    label: k,
+    data: metrics.cohorts.data.map(c => (c[k] / c.total) * 100),
+    backgroundColor: ['#8884d8', '#82ca9d', '#ffc658'][idx]
+  }))
+
+  const plat = metrics.platforms
+  const totalDevice = Object.values(plat.device).reduce((a, b) => a + b, 0)
+  const totalOs = Object.values(plat.os).reduce((a, b) => a + b, 0)
+  const totalBrowser = Object.values(plat.browser).reduce((a, b) => a + b, 0)
+  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#413ea0', '#ff0000']
+  const platformDatasets = [
+    ...Object.entries(plat.device).map(([k, v], i) => ({ label: k, data: [(v / totalDevice) * 100, 0, 0], stack: 'device', backgroundColor: colors[i % colors.length] })),
+    ...Object.entries(plat.os).map(([k, v], i) => ({ label: k, data: [0, (v / totalOs) * 100, 0], stack: 'os', backgroundColor: colors[(i + 2) % colors.length] })),
+    ...Object.entries(plat.browser).map(([k, v], i) => ({ label: k, data: [0, 0, (v / totalBrowser) * 100], stack: 'browser', backgroundColor: colors[(i + 4) % colors.length] }))
+  ]
+
+  return (
+    <div>
+      <h1>{title}</h1>
+
+      <section>
+        <Bar
+          data={{
+            labels: metrics.dates,
+            datasets: [
+              { label: 'Sessions', data: metrics.sessions, backgroundColor: '#8884d8' },
+              { label: 'Conversion', data: metrics.conv.map(v => v * 100), type: 'line', borderColor: '#ff7300', yAxisID: 'y1' }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true }, y1: { beginAtZero: true, position: 'right' } } }}
+        />
+        <p>Goal: load vs conversion; Formula: signups/visits; Source: activity.json; Period: {metrics.period}</p>
+      </section>
+
+      <section>
+        <Line
+          data={{
+            labels: metrics.dates,
+            datasets: [
+              { label: 'Stickiness', data: metrics.stickiness, borderColor: '#82ca9d' },
+              { label: '0.3', data: metrics.dates.map(() => 0.3), borderColor: '#ff0000', borderDash: [5, 5] },
+              { label: '0.5', data: metrics.dates.map(() => 0.5), borderColor: '#0000ff', borderDash: [5, 5] }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true, max: 1 } } }}
+        />
+        <p>Goal: product stickiness; Formula: DAU/MAU; Source: events.json; Reference lines at 0.3 and 0.5; Period: {metrics.period}</p>
+      </section>
+
+      <section>
+        <Bar
+          data={{ labels: metrics.cohorts.weeks, datasets: cohortDatasets }}
+          options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }}
+        />
+        <p>Goal: retention by cohorts; Method: lastActiveAt vs createdAt; Source: users.json</p>
+      </section>
+
+      <section>
+        <Bar
+          data={{ labels: ['Device', 'OS', 'Browser'], datasets: platformDatasets }}
+          options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }}
+        />
+        <p>Goal: platform profile of active users; Source: users.json; Metric: share of device/os/browser</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -1,0 +1,111 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import {
+  loadAll,
+  groupEventsByDate,
+  activityMapByDate,
+  dateRange,
+  computeDAU,
+  computeWindowAU,
+  computeSMA,
+  computeNewReturning,
+  visitsPerDay,
+  signupsPerDay,
+  loginsPerDay,
+  loginsByWeekday
+} from '../data/analytics.js'
+
+export default function AdminGraphGrowthPage() {
+  const title = 'Growth Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    loadAll().then(setData)
+  }, [])
+
+  const metrics = useMemo(() => {
+    if (!data) return null
+    const { events, activity } = data
+    const { map: eventMap, firstSeen } = groupEventsByDate(events)
+    const activityMap = activityMapByDate(activity)
+    const dates = dateRange(activity[0].date, activity[activity.length - 1].date)
+    const dau = computeDAU(dates, eventMap)
+    const wau = computeWindowAU(dates, eventMap, 7)
+    const mau = computeWindowAU(dates, eventMap, 30)
+    const dauSMA = computeSMA(dau, 7)
+    const newRet = computeNewReturning(dates, events, firstSeen)
+    const visits = visitsPerDay(dates, activityMap)
+    const signups = signupsPerDay(dates, activityMap)
+    const logins = loginsPerDay(dates, activityMap)
+    const loginsWeekday = loginsByWeekday(events)
+    return { dates, dau, wau, mau, dauSMA, newRet, visits, signups, logins, loginsWeekday, period: `${dates[0]} to ${dates[dates.length-1]}` }
+  }, [data])
+
+  if (!metrics) return <p>Loading...</p>
+
+  const weekLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+  return (
+    <div>
+      <h1>{title}</h1>
+      <section>
+        <Line
+          data={{
+            labels: metrics.dates,
+            datasets: [
+              { label: 'DAU', data: metrics.dau, borderColor: '#8884d8', backgroundColor: 'rgba(136,132,216,0.3)', fill: true, stack: 'a' },
+              { label: 'WAU', data: metrics.wau, borderColor: '#82ca9d', backgroundColor: 'rgba(130,202,157,0.3)', fill: true, stack: 'a' },
+              { label: 'MAU', data: metrics.mau, borderColor: '#ffc658', backgroundColor: 'rgba(255,198,88,0.3)', fill: true, stack: 'a' },
+              { label: 'DAU SMA7', data: metrics.dauSMA, borderColor: '#ff7300', fill: false }
+            ]
+          }}
+        />
+        <p>Goal: compare active user scales; Source: events.json; Formulas: DAU/WAU/MAU, SMA7 on DAU; Period: {metrics.period}</p>
+      </section>
+
+      <section>
+        <Line
+          data={{
+            labels: metrics.dates,
+            datasets: [
+              { label: 'New', data: metrics.newRet.map(d => d.new), borderColor: '#413ea0', backgroundColor: 'rgba(65,62,160,0.3)', fill: true, stack: 'b' },
+              { label: 'Returning', data: metrics.newRet.map(d => d.returning), borderColor: '#ff0000', backgroundColor: 'rgba(255,0,0,0.3)', fill: true, stack: 'b' }
+            ]
+          }}
+        />
+        <p>Goal: share of new vs returning users; Rule: user is new if no prior events; Source: events.json; Period: {metrics.period}</p>
+      </section>
+
+      <section>
+        <Line
+          data={{
+            labels: metrics.dates,
+            datasets: [
+              { label: 'Visits', data: metrics.visits, borderColor: '#8884d8' },
+              { label: 'Signups', data: metrics.signups, borderColor: '#82ca9d' },
+              { label: 'Logins', data: metrics.logins, borderColor: '#ff7300' }
+            ]
+          }}
+        />
+        <p>Goal: daily funnel dynamics; Source: activity.json; Metrics: visits, signups, logins; Period: {metrics.period}</p>
+      </section>
+
+      <section>
+        <Bar
+          data={{
+            labels: weekLabels,
+            datasets: [{ label: 'Logins', data: metrics.loginsWeekday, backgroundColor: '#82ca9d' }]
+          }}
+        />
+        <p>Goal: weekday seasonality of logins; Source: events.json; Method: count logins per weekday</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphPage.jsx
+++ b/src/admin/pages/adminGraphPage.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+
+export default function AdminGraphPage() {
+  const title = 'Admin Graphs'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{title}</h1>
+      <p>Select a graph from subpages.</p>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import {
+  loadAll,
+  groupEventsByDate,
+  activityMapByDate,
+  dateRange,
+  errorRate,
+  errorsByCodePerDay,
+  errorTotalsByCode,
+  errorEventsByPage
+} from '../data/analytics.js'
+
+export default function AdminGraphReliabilityPage() {
+  const title = 'Reliability Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    loadAll().then(setData)
+  }, [])
+
+  const metrics = useMemo(() => {
+    if (!data) return null
+    const { events, activity } = data
+    const { map: eventMap } = groupEventsByDate(events)
+    const activityMap = activityMapByDate(activity)
+    const dates = dateRange(activity[0].date, activity[activity.length - 1].date)
+    const errRate = errorRate(dates, activityMap)
+    const codePerDay = errorsByCodePerDay(dates, activityMap)
+    const totals = errorTotalsByCode(activity)
+    const byPage = errorEventsByPage(eventMap)
+    return { dates, errRate, codePerDay, totals, byPage, period: `${dates[0]} to ${dates[dates.length-1]}` }
+  }, [data])
+
+  if (!metrics) return <p>Loading...</p>
+
+  const slo = 0.02
+
+  return (
+    <div>
+      <h1>{title}</h1>
+
+      <section>
+        <Line
+          data={{
+            labels: metrics.dates,
+            datasets: [
+              { label: 'Error rate', data: metrics.errRate, borderColor: '#ff7300' },
+              { label: 'SLO', data: metrics.dates.map(() => slo), borderColor: '#000', borderDash: [5, 5] }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true } } }}
+        />
+        <p>Goal: stability per session; Formula: errors/sessions; Source: activity.json; Period: {metrics.period}</p>
+      </section>
+
+      <section>
+        <Line
+          data={{
+            labels: metrics.dates,
+            datasets: metrics.codePerDay.codes.map((c, i) => ({
+              label: c,
+              data: metrics.codePerDay.data[c],
+              borderColor: ['#8884d8', '#82ca9d', '#ffc658', '#ff7300'][i],
+              backgroundColor: ['rgba(136,132,216,0.3)', 'rgba(130,202,157,0.3)', 'rgba(255,198,88,0.3)', 'rgba(255,115,0,0.3)'][i],
+              fill: true,
+              stack: 'codes'
+            }))
+          }}
+        />
+        <p>Goal: error structure by code; Source: activity.json</p>
+      </section>
+
+      <section>
+        <Bar
+          data={{
+            labels: metrics.totals.entries.map(e => e[0]),
+            datasets: [
+              { label: 'Errors', data: metrics.totals.entries.map(e => e[1]), backgroundColor: '#8884d8' },
+              { label: 'Cum %', data: metrics.totals.cumPct.map(c => c.pct), type: 'line', borderColor: '#ff0000', yAxisID: 'y1' }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true }, y1: { beginAtZero: true, max: 100, position: 'right' } } }}
+        />
+        <p>Goal: Pareto of error codes; Source: activity.json</p>
+      </section>
+
+      <section>
+        <Bar
+          data={{
+            labels: metrics.byPage.map(p => p[0]),
+            datasets: [
+              { label: 'Errors', data: metrics.byPage.map(p => p[1]), backgroundColor: '#82ca9d' }
+            ]
+          }}
+          options={{ indexAxis: 'y' }}
+        />
+        <p>Goal: problematic pages; Source: events.json; Method: error events per page (top 10)</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Bar, Line } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import {
+  loadAll,
+  groupEventsByDate,
+  activityMapByDate,
+  dateRange,
+  signupsPerDay,
+  subsPerDay,
+  funnelTotals,
+  subscriptionSegments,
+  cumulativeUsers
+} from '../data/analytics.js'
+
+export default function AdminGraphRevenuePage() {
+  const title = 'Revenue Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    loadAll().then(setData)
+  }, [])
+
+  const metrics = useMemo(() => {
+    if (!data) return null
+    const { events, activity, users } = data
+    const { map: eventMap } = groupEventsByDate(events)
+    const activityMap = activityMapByDate(activity)
+    const dates = dateRange(activity[0].date, activity[activity.length - 1].date)
+    const signups = signupsPerDay(dates, activityMap)
+    const subs = subsPerDay(dates, eventMap)
+    const funnel = funnelTotals(eventMap)
+    const segments = subscriptionSegments(events, users)
+    const cumulative = cumulativeUsers(users)
+    return { dates, signups, subs, funnel, segments, cumulative, period: `${dates[0]} to ${dates[dates.length-1]}` }
+  }, [data])
+
+  if (!metrics) return <p>Loading...</p>
+
+  const funnelLabels = ['visit', 'signup', 'verify', 'login', 'first_action', 'subscribe']
+  const segments = metrics.segments
+  const segTotals = {
+    plan: Object.values(segments.plan).reduce((a, b) => a + b, 0),
+    utmSource: Object.values(segments.utmSource).reduce((a, b) => a + b, 0),
+    country: Object.values(segments.country).reduce((a, b) => a + b, 0)
+  }
+  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#413ea0', '#ff0000']
+  const segmentDatasets = [
+    ...Object.entries(segments.plan).map(([k, v], i) => ({ label: k, data: [(v / segTotals.plan) * 100, 0, 0], stack: 'plan', backgroundColor: colors[i % colors.length] })),
+    ...Object.entries(segments.utmSource).map(([k, v], i) => ({ label: k, data: [0, (v / segTotals.utmSource) * 100, 0], stack: 'utm', backgroundColor: colors[(i + 2) % colors.length] })),
+    ...Object.entries(segments.country).map(([k, v], i) => ({ label: k, data: [0, 0, (v / segTotals.country) * 100], stack: 'country', backgroundColor: colors[(i + 4) % colors.length] }))
+  ]
+
+  return (
+    <div>
+      <h1>{title}</h1>
+
+      <section>
+        <Bar
+          data={{ labels: funnelLabels, datasets: [{ label: 'Events', data: funnelLabels.map(l => metrics.funnel[l]), backgroundColor: '#8884d8' }] }}
+        />
+        <p>Goal: drop-off across funnel steps; Source: events.json</p>
+      </section>
+
+      <section>
+        <Bar
+          data={{ labels: ['Plan', 'UTM', 'Country'], datasets: segmentDatasets }}
+          options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }}
+        />
+        <p>Goal: subscription segments; Source: events.json + users.json</p>
+      </section>
+
+      <section>
+        <Bar
+          data={{
+            labels: metrics.dates,
+            datasets: [
+              { label: 'Signups', data: metrics.signups, backgroundColor: '#82ca9d' },
+              { label: 'Subscribes', data: metrics.subs, type: 'line', borderColor: '#ff7300', yAxisID: 'y1' }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true }, y1: { beginAtZero: true, position: 'right' } } }}
+        />
+        <p>Goal: inflow vs paid conversions; Sources: activity.json & events.json; Period: {metrics.period}</p>
+      </section>
+
+      <section>
+        <Line
+          data={{ labels: metrics.cumulative.dates, datasets: [{ label: 'Cumulative users', data: metrics.cumulative.values, borderColor: '#413ea0' }] }}
+        />
+        <p>Goal: user base growth; Source: users.json</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/urlTree.json
+++ b/src/urlTree.json
@@ -7,6 +7,7 @@
     "children": [
       { "path": "/admin/login", "name": "Login", "children": [] },
       { "path": "/admin/logout", "name": "Logout", "children": [] },
+      { "path": "/admin/dashboard", "name": "Dashboard", "children": [] },
       {
         "path": "/admin/charts",
         "name": "Charts",
@@ -20,6 +21,16 @@
               { "path": "/admin/charts/users/explain", "name": "Explain", "children": [] }
             ]
           }
+        ]
+      },
+      {
+        "path": "/admin/graph",
+        "name": "Graph",
+        "children": [
+          { "path": "/admin/graph/growth", "name": "Growth", "children": [] },
+          { "path": "/admin/graph/engagement", "name": "Engagement", "children": [] },
+          { "path": "/admin/graph/reliability", "name": "Reliability", "children": [] },
+          { "path": "/admin/graph/revenue", "name": "Revenue", "children": [] }
         ]
       },
       { "path": "/admin/ui", "name": "UI", "children": [] }


### PR DESCRIPTION
## Summary
- add `/admin/dashboard` with mini metrics and links to new analytics pages
- implement growth, engagement, reliability, and revenue charts using real mock data
- document analytics features and bump version to 0.0.52

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b281c15dec832e8af1a770cc3837fc