### PR TITLE
feat: add admin analytics dashboard and metrics pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.51
+Current version: 0.0.52
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -15,6 +15,7 @@ Current version: 0.0.51
 - User and admin sidebars highlight the active link
 - Admin charts with 20 Recharts examples for users data
 - Admin charts with 21 Chart.js examples for users data
+- Admin dashboard with growth, engagement, reliability, and revenue analytics
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -110,6 +111,13 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+
+18. Админ аналитика
+  - [x] 18.1 Добавить /admin/dashboard с мини-графиками
+  - [x] 18.2 Создать страницу /admin/graph/growth
+  - [x] 18.3 Создать страницу /admin/graph/engagement
+  - [x] 18.4 Создать страницу /admin/graph/reliability
+  - [x] 18.5 Создать страницу /admin/graph/revenue
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1327,6 +1327,40 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added admin dashboard with mini metric charts",
+          "weight": 70,
+          "type": "feat",
+          "scope": "dashboard"
+        },
+        {
+          "description": "Introduced growth, engagement, reliability and revenue analytics pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена админ-панель с мини-графиками показателей",
+          "weight": 70,
+          "type": "feat",
+          "scope": "dashboard"
+        },
+        {
+          "description": "Добавлены страницы аналитики роста, вовлечённости, стабильности и доходов",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2545,6 +2579,40 @@
           "weight": 30,
           "type": "refactor",
           "scope": "navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added admin dashboard with mini metric charts",
+          "weight": 70,
+          "type": "feat",
+          "scope": "dashboard"
+        },
+        {
+          "description": "Introduced growth, engagement, reliability and revenue analytics pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена админ-панель с мини-графиками показателей",
+          "weight": 70,
+          "type": "feat",
+          "scope": "dashboard"
+        },
+        {
+          "description": "Добавлены страницы аналитики роста, вовлечённости, стабильности и доходов",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
         }
       ]
     }

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -7,11 +7,29 @@ import AdminChartsUsersExplainPage from '../pages/adminChartsUsersExplainPage.js
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+import AdminDashboardPage from '../pages/adminDashboardPage.jsx'
+import AdminGraphPage from '../pages/adminGraphPage.jsx'
+import AdminGraphGrowthPage from '../pages/adminGraphGrowthPage.jsx'
+import AdminGraphEngagementPage from '../pages/adminGraphEngagementPage.jsx'
+import AdminGraphReliabilityPage from '../pages/adminGraphReliabilityPage.jsx'
+import AdminGraphRevenuePage from '../pages/adminGraphRevenuePage.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
   { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
   { index: true, element: <AdminPage />, label: 'Home' },
+  { path: 'dashboard', element: <AdminDashboardPage />, label: 'Dashboard' },
+  {
+    path: 'graph',
+    element: <AdminGraphPage />,
+    label: 'Graph',
+    children: [
+      { path: 'growth', element: <AdminGraphGrowthPage />, label: 'Growth' },
+      { path: 'engagement', element: <AdminGraphEngagementPage />, label: 'Engagement' },
+      { path: 'reliability', element: <AdminGraphReliabilityPage />, label: 'Reliability' },
+      { path: 'revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' }
+    ]
+  },
   {
     path: 'charts',
     element: <AdminChartsPage />,

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import { useAnalytics } from '../utils/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminDashboardPage() {
+  const title = 'Admin Dashboard Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const data = useAnalytics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!data) return <p>Loading...</p>
+
+  const period = `${data.dates[0]} – ${data.dates[data.dates.length - 1]}`
+
+  const tiles = [
+    {
+      title: 'Growth',
+      chart: <Line height={80} data={{ labels: data.dates, datasets: [{ data: data.dau, borderColor: '#8884d8', fill: false }] }} options={{ plugins:{legend:{display:false}}, scales:{x:{display:false},y:{display:false}} }} />, link: '/admin/graph/growth', caption: 'Source: events.json; Formula: DAU=distinct userId per day; Period: ' + period
+    },
+    {
+      title: 'Engagement',
+      chart: <Line height={80} data={{ labels: data.dates, datasets: [{ data: data.conversion, borderColor: '#82ca9d', fill: false }] }} options={{ plugins:{legend:{display:false}}, scales:{x:{display:false},y:{display:false}} }} />, link: '/admin/graph/engagement', caption: 'Source: activity.json; Formula: signups/visits; Period: ' + period
+    },
+    {
+      title: 'Reliability',
+      chart: <Line height={80} data={{ labels: data.dates, datasets: [{ data: data.errorRate, borderColor: '#ff7300', fill: false }] }} options={{ plugins:{legend:{display:false}}, scales:{x:{display:false},y:{display:false}} }} />, link: '/admin/graph/reliability', caption: 'Source: activity.json; Formula: errors/sessions; Period: ' + period
+    },
+    {
+      title: 'Revenue',
+      chart: <Bar height={80} data={{ labels: data.dates, datasets: [{ data: data.subsPerDay, backgroundColor: '#ffc658' }] }} options={{ plugins:{legend:{display:false}}, scales:{x:{display:false},y:{display:false}} }} />, link: '/admin/graph/revenue', caption: 'Source: events.json; Formula: subscriptions per day; Period: ' + period
+    }
+  ]
+
+  return (
+    <div>
+      <h1>{title}</h1>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(200px,1fr))', gap: '1rem' }}>
+        {tiles.map(t => (
+          <Link key={t.title} to={t.link} style={{ textDecoration: 'none', color: 'inherit' }}>
+            <div style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+              {t.chart}
+              <p style={{ fontSize: '0.8rem' }}>{t.caption}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import { useAnalytics } from '../utils/analytics.js'
+
+const refLines = {
+  id: 'refLines',
+  afterDraw: chart => {
+    const lines = chart.options.refLines || []
+    const { ctx, chartArea: { left, right }, scales: { y } } = chart
+    lines.forEach(l => {
+      const yPos = y.getPixelForValue(l.value)
+      ctx.save()
+      ctx.strokeStyle = l.color || 'red'
+      ctx.beginPath()
+      ctx.moveTo(left, yPos)
+      ctx.lineTo(right, yPos)
+      ctx.stroke()
+      ctx.restore()
+    })
+  }
+}
+
+ChartJS.register(...registerables, refLines)
+
+export default function AdminGraphEngagementPage() {
+  const title = 'Admin Graph Engagement Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const data = useAnalytics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!data) return <p>Loading...</p>
+  const period = `${data.dates[0]} – ${data.dates[data.dates.length - 1]}`
+
+  const mixedSessionsConversion = {
+    labels: data.dates,
+    datasets: [
+      { type: 'bar', label: 'Sessions', data: data.sessions, backgroundColor: '#8884d8', yAxisID: 'y' },
+      { type: 'line', label: 'Conversion %', data: data.conversion, borderColor: '#ff7300', yAxisID: 'y1', fill: false }
+    ]
+  }
+  const stickinessLine = {
+    labels: data.dates,
+    datasets: [
+      { label: 'Stickiness', data: data.stickiness, borderColor: '#82ca9d', fill: false }
+    ]
+  }
+  const cohorts = {
+    labels: data.cohorts.map(c => c.week),
+    datasets: [
+      { label: 'd+7', data: data.cohorts.map(c => c.d7), backgroundColor: '#8884d8' },
+      { label: 'd+14', data: data.cohorts.map(c => c.d14), backgroundColor: '#82ca9d' },
+      { label: 'd+28', data: data.cohorts.map(c => c.d28), backgroundColor: '#ffc658' }
+    ]
+  }
+  const platformStacks = () => {
+    const labels = ['Device', 'OS', 'Browser']
+    const datasets = []
+    Object.entries(data.platforms.device).forEach(([k, v]) => {
+      datasets.push({ label: k, data: [v, 0, 0], backgroundColor: '#8884d8', stack: 'device' })
+    })
+    Object.entries(data.platforms.os).forEach(([k, v]) => {
+      datasets.push({ label: k, data: [0, v, 0], backgroundColor: '#82ca9d', stack: 'os' })
+    })
+    Object.entries(data.platforms.browser).forEach(([k, v]) => {
+      datasets.push({ label: k, data: [0, 0, v], backgroundColor: '#ffc658', stack: 'browser' })
+    })
+    return { labels, datasets }
+  }
+
+  return (
+    <div>
+      <h1>{title}</h1>
+      <div>
+        <Bar data={mixedSessionsConversion} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
+        <p><strong>Sessions vs Conversion:</strong> Load vs conversion ratio; Source: activity.json; Formula: signups/visits; Period: {period}</p>
+      </div>
+      <div>
+        <Line data={stickinessLine} options={{ refLines: [{ value: 0.3, color: 'red' }, { value: 0.5, color: 'orange' }], plugins: { legend: { display: true } }, scales: { y: { min: 0, max: 1 } } }} />
+        <p><strong>Stickiness:</strong> DAU/MAU showing engagement; Source: events.json; Formula: DAU/MAU; Period: {period}</p>
+      </div>
+      <div>
+        <Bar data={cohorts} options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }} />
+        <p><strong>Retention cohorts:</strong> d+7/d+14/d+28 retention by signup week; Source: users.json; Method: lastActive - createdAt; Period: all users</p>
+      </div>
+      <div>
+        <Bar data={platformStacks()} options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }} />
+        <p><strong>Platform profile:</strong> Device/OS/Browser shares; Source: users.json; Method: distribution of active users; Period: all users</p>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import { useAnalytics } from '../utils/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminGraphGrowthPage() {
+  const title = 'Admin Graph Growth Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const data = useAnalytics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!data) return <p>Loading...</p>
+  const period = `${data.dates[0]} – ${data.dates[data.dates.length - 1]}`
+
+  const areaStack = {
+    labels: data.dates,
+    datasets: [
+      { label: 'DAU', data: data.dau, borderColor: '#8884d8', backgroundColor: '#8884d8', fill: true, stack: 'a' },
+      { label: 'WAU', data: data.wau, borderColor: '#82ca9d', backgroundColor: '#82ca9d', fill: true, stack: 'a' },
+      { label: 'MAU', data: data.mau, borderColor: '#ffc658', backgroundColor: '#ffc658', fill: true, stack: 'a' },
+      { label: 'SMA7', data: data.sma7, borderColor: '#ff7300', fill: false }
+    ]
+  }
+  const newReturn = {
+    labels: data.dates,
+    datasets: [
+      { label: 'New', data: data.newUsers, borderColor: '#413ea0', backgroundColor: '#413ea0', fill: true, stack: 'b' },
+      { label: 'Returning', data: data.returningUsers, borderColor: '#82ca9d', backgroundColor: '#82ca9d', fill: true, stack: 'b' }
+    ]
+  }
+  const funnelLines = {
+    labels: data.dates,
+    datasets: [
+      { label: 'Visits', data: data.visits, borderColor: '#8884d8', fill: false },
+      { label: 'Signups', data: data.signups, borderColor: '#82ca9d', fill: false },
+      { label: 'Logins', data: data.logins, borderColor: '#ff7300', fill: false }
+    ]
+  }
+  const loginsByWeekday = {
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    datasets: [
+      { label: 'Logins', data: data.loginsByWeekday, backgroundColor: '#8884d8' }
+    ]
+  }
+
+  return (
+    <div>
+      <h1>{title}</h1>
+      <div>
+        <Line data={areaStack} options={{ plugins: { title: { display: false } } }} />
+        <p><strong>DAU/WAU/MAU:</strong> Compare active user base sizes; Source: events.json; Method: distinct user counts with 7/30-day windows and SMA7; Period: {period}</p>
+      </div>
+      <div>
+        <Line data={newReturn} options={{ plugins: { title: { display: false } }, scales: { y: { stacked: true } } }} />
+        <p><strong>New vs Returning:</strong> Share of first-time vs repeat users; Source: events.json; Method: classify by first event; Period: {period}</p>
+      </div>
+      <div>
+        <Line data={funnelLines} />
+        <p><strong>Visits/Signups/Logins:</strong> Daily funnel progression; Source: activity.json; Method: direct counts per day; Period: {period}</p>
+      </div>
+      <div>
+        <Bar data={loginsByWeekday} />
+        <p><strong>Logins by Weekday:</strong> Seasonality pattern; Source: events.json; Method: count logins grouped by weekday; Period: {period}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphPage.jsx
+++ b/src/admin/pages/adminGraphPage.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+export default function AdminGraphPage() {
+  const title = 'Admin Graph Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{title}</h1>
+      <p>Choose a metric category.</p>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -1,0 +1,88 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import { useAnalytics } from '../utils/analytics.js'
+
+const refLines = {
+  id: 'refLines',
+  afterDraw: chart => {
+    const lines = chart.options.refLines || []
+    const { ctx, chartArea: { left, right }, scales: { y } } = chart
+    lines.forEach(l => {
+      const yPos = y.getPixelForValue(l.value)
+      ctx.save()
+      ctx.strokeStyle = l.color || 'red'
+      ctx.beginPath()
+      ctx.moveTo(left, yPos)
+      ctx.lineTo(right, yPos)
+      ctx.stroke()
+      ctx.restore()
+    })
+  }
+}
+
+ChartJS.register(...registerables, refLines)
+
+export default function AdminGraphReliabilityPage() {
+  const title = 'Admin Graph Reliability Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const data = useAnalytics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!data) return <p>Loading...</p>
+  const period = `${data.dates[0]} – ${data.dates[data.dates.length - 1]}`
+
+  const errorRateLine = {
+    labels: data.dates,
+    datasets: [
+      { label: 'Error Rate', data: data.errorRate, borderColor: '#ff7300', fill: false }
+    ]
+  }
+  const errorsArea = {
+    labels: data.dates,
+    datasets: [
+      { label: '401', data: data.errorsByCode['401'], borderColor: '#8884d8', backgroundColor: '#8884d8', fill: true, stack: 'c' },
+      { label: '408', data: data.errorsByCode['408'], borderColor: '#82ca9d', backgroundColor: '#82ca9d', fill: true, stack: 'c' },
+      { label: '500', data: data.errorsByCode['500'], borderColor: '#ffc658', backgroundColor: '#ffc658', fill: true, stack: 'c' },
+      { label: 'JS:TypeError', data: data.errorsByCode['JS:TypeError'], borderColor: '#413ea0', backgroundColor: '#413ea0', fill: true, stack: 'c' }
+    ]
+  }
+  const pareto = {
+    labels: data.pareto.map(p => p.code),
+    datasets: [
+      { type: 'bar', label: 'Errors', data: data.pareto.map(p => p.count), backgroundColor: '#8884d8', yAxisID: 'y' },
+      { type: 'line', label: 'Cumulative %', data: data.pareto.map(p => p.cumPct), borderColor: '#ff7300', yAxisID: 'y1', fill: false }
+    ]
+  }
+  const pageErrors = {
+    labels: data.errorPageTop.map(([p]) => p),
+    datasets: [
+      { label: 'Errors', data: data.errorPageTop.map(([, c]) => c), backgroundColor: '#ff7300' }
+    ]
+  }
+
+  return (
+    <div>
+      <h1>{title}</h1>
+      <div>
+        <Line data={errorRateLine} options={{ refLines: [{ value: 0.02, color: 'red' }], scales: { y: { beginAtZero: true } } }} />
+        <p><strong>Error rate:</strong> Stability per session; Source: activity.json; Formula: errors/sessions; Period: {period}</p>
+      </div>
+      <div>
+        <Line data={errorsArea} options={{ scales: { y: { stacked: true } } }} />
+        <p><strong>Error codes:</strong> Structure of incidents; Source: activity.json; Method: errors grouped by code; Period: {period}</p>
+      </div>
+      <div>
+        <Bar data={pareto} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' }, beginAtZero: true, max: 100 } } }} />
+        <p><strong>Pareto:</strong> Top error contributors; Source: activity.json; Method: cumulative 80/20; Period: {period}</p>
+      </div>
+      <div>
+        <Bar data={pageErrors} options={{ indexAxis: 'y' }} />
+        <p><strong>Error pages:</strong> Problematic pages; Source: events.json; Method: count error events per page; Period: {period}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import { useAnalytics } from '../utils/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminGraphRevenuePage() {
+  const title = 'Admin Graph Revenue Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const data = useAnalytics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!data) return <p>Loading...</p>
+  const period = `${data.dates[0]} – ${data.dates[data.dates.length - 1]}`
+
+  const funnel = {
+    labels: Object.keys(data.funnelTotals),
+    datasets: [
+      { label: 'Count', data: Object.values(data.funnelTotals), backgroundColor: '#8884d8' }
+    ]
+  }
+  const segChart = () => {
+    const labels = ['Plan', 'UTM', 'Country']
+    const datasets = []
+    Object.entries(data.seg.plan).forEach(([k, v]) => datasets.push({ label: k, data: [v, 0, 0], backgroundColor: '#8884d8', stack: 'plan' }))
+    Object.entries(data.seg.utmSource).forEach(([k, v]) => datasets.push({ label: k, data: [0, v, 0], backgroundColor: '#82ca9d', stack: 'utm' }))
+    Object.entries(data.seg.country).forEach(([k, v]) => datasets.push({ label: k, data: [0, 0, v], backgroundColor: '#ffc658', stack: 'country' }))
+    return { labels, datasets }
+  }
+  const signupSub = {
+    labels: data.dates,
+    datasets: [
+      { type: 'bar', label: 'Signups', data: data.signups, backgroundColor: '#8884d8', yAxisID: 'y' },
+      { type: 'line', label: 'Subscriptions', data: data.subsPerDay, borderColor: '#ff7300', fill: false, yAxisID: 'y1' }
+    ]
+  }
+  const cumulative = {
+    labels: data.cumulativeUsers.map(c => c.date),
+    datasets: [
+      { label: 'Users', data: data.cumulativeUsers.map(c => c.count), borderColor: '#82ca9d', fill: false }
+    ]
+  }
+
+  return (
+    <div>
+      <h1>{title}</h1>
+      <div>
+        <Bar data={funnel} />
+        <p><strong>Funnel totals:</strong> Drop-off per step; Source: events.json; Method: count events by type; Period: {period}</p>
+      </div>
+      <div>
+        <Bar data={segChart()} options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }} />
+        <p><strong>Subscription segments:</strong> Shares by plan/utm/country; Source: events+users.json; Method: join subscribe→users; Period: {period}</p>
+      </div>
+      <div>
+        <Bar data={signupSub} options={{ scales: { y: { position: 'left' }, y1: { position: 'right' } } }} />
+        <p><strong>Signups vs Subs:</strong> Free vs paid flow; Source: activity/events; Method: daily signups and subscriptions; Period: {period}</p>
+      </div>
+      <div>
+        <Line data={cumulative} />
+        <p><strong>Cumulative users:</strong> Base growth; Source: users.json; Method: cumulative sum by createdAt; Period: full user history</p>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/utils/analytics.js
+++ b/src/admin/utils/analytics.js
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react'
+
+const fmt = d => d.toISOString().slice(0, 10)
+
+const getDates = (start, end) => {
+  const arr = []
+  for (let dt = new Date(start); dt <= end; dt.setUTCDate(dt.getUTCDate() + 1)) {
+    arr.push(fmt(new Date(dt)))
+  }
+  return arr
+}
+
+const getISOWeek = date => {
+  const tmp = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - (tmp.getUTCDay() || 7))
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1))
+  const weekNo = Math.ceil(((tmp - yearStart) / 86400000 + 1) / 7)
+  return `${tmp.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`
+}
+
+export function useAnalytics() {
+  const [data, setData] = useState(null)
+  useEffect(() => {
+    Promise.all([
+      fetch('/mocks/activity.json').then(r => r.json()),
+      fetch('/mocks/events.json').then(r => r.json()),
+      fetch('/mocks/users.json').then(r => r.json())
+    ]).then(([activity, events, users]) => {
+      const activityMap = Object.fromEntries(activity.map(a => [a.date, a]))
+      const eventByDate = {}
+      const firstSeen = new Map()
+      const errorPageCounts = {}
+      const errorTotals = {}
+      const subsByDate = {}
+      const funnelTypes = ['visit', 'signup', 'verify', 'login', 'first_action', 'subscribe']
+      const funnelTotals = Object.fromEntries(funnelTypes.map(t => [t, 0]))
+      const dauSets = {}
+      const loginsByWeekday = Array(7).fill(0)
+      events.forEach(ev => {
+        const date = ev.ts.slice(0, 10)
+        if (!eventByDate[date]) eventByDate[date] = []
+        eventByDate[date].push(ev)
+        if (!dauSets[date]) dauSets[date] = new Set()
+        dauSets[date].add(ev.userId)
+        if (!firstSeen.has(ev.userId) || date < firstSeen.get(ev.userId)) firstSeen.set(ev.userId, date)
+        if (ev.type === 'login') {
+          const day = (new Date(ev.ts).getUTCDay() + 6) % 7
+          loginsByWeekday[day]++
+        }
+        if (ev.type === 'error') {
+          errorPageCounts[ev.page] = (errorPageCounts[ev.page] || 0) + 1
+          const code = ev.code || 'unknown'
+          errorTotals[code] = (errorTotals[code] || 0) + 1
+        }
+        if (ev.type === 'subscribe') {
+          subsByDate[date] = (subsByDate[date] || 0) + 1
+        }
+        if (funnelTotals[ev.type] !== undefined) funnelTotals[ev.type]++
+      })
+      const allDates = getDates(new Date(Math.min(...activity.map(a => Date.parse(a.date)))), new Date(Math.max(...activity.map(a => Date.parse(a.date)))))
+      const dau = allDates.map(d => (dauSets[d] ? dauSets[d].size : 0))
+      const wau = allDates.map((d, i) => {
+        const start = Math.max(0, i - 6)
+        const set = new Set()
+        for (let j = start; j <= i; j++) {
+          dauSets[allDates[j]]?.forEach(u => set.add(u))
+        }
+        return set.size
+      })
+      const mau = allDates.map((d, i) => {
+        const start = Math.max(0, i - 29)
+        const set = new Set()
+        for (let j = start; j <= i; j++) {
+          dauSets[allDates[j]]?.forEach(u => set.add(u))
+        }
+        return set.size
+      })
+      const sma7 = dau.map((_, i) => {
+        const start = Math.max(0, i - 6)
+        const slice = dau.slice(start, i + 1)
+        const avg = slice.reduce((a, b) => a + b, 0) / slice.length
+        return avg
+      })
+      const newUsers = allDates.map(d => {
+        let c = 0
+        dauSets[d]?.forEach(u => {
+          if (firstSeen.get(u) === d) c++
+        })
+        return c
+      })
+      const returningUsers = dau.map((v, i) => v - newUsers[i])
+      const conversion = allDates.map(d => {
+        const a = activityMap[d]
+        return a && a.visits ? (a.signups / a.visits) * 100 : 0
+      })
+      const errorRate = allDates.map(d => {
+        const a = activityMap[d]
+        return a && a.sessions ? a.errors / a.sessions : 0
+      })
+      const sessions = allDates.map(d => activityMap[d]?.sessions || 0)
+      const visits = allDates.map(d => activityMap[d]?.visits || 0)
+      const signups = allDates.map(d => activityMap[d]?.signups || 0)
+      const logins = allDates.map(d => activityMap[d]?.logins || 0)
+      const errorsByCode = { '401': [], '408': [], '500': [], 'JS:TypeError': [] }
+      allDates.forEach(d => {
+        const e = activityMap[d]?.errorsByCode || {}
+        Object.keys(errorsByCode).forEach(code => {
+          errorsByCode[code].push(e[code] || 0)
+        })
+      })
+      const stickiness = dau.map((v, i) => (mau[i] ? v / mau[i] : 0))
+      const subsPerDay = allDates.map(d => subsByDate[d] || 0)
+      const errorPageTop = Object.entries(errorPageCounts).sort((a, b) => b[1] - a[1]).slice(0, 10)
+      const errorCodeTotals = Object.entries(errorTotals).sort((a, b) => b[1] - a[1])
+      const totalErrors = errorCodeTotals.reduce((a, [, c]) => a + c, 0)
+      let cum = 0
+      const pareto = errorCodeTotals.map(([code, c]) => {
+        cum += c
+        return { code, count: c, cumPct: totalErrors ? (cum / totalErrors) * 100 : 0 }
+      })
+      const userMap = new Map(users.map(u => [u.id, u]))
+      const subsEvents = events.filter(e => e.type === 'subscribe')
+      const seg = { plan: {}, utmSource: {}, country: {} }
+      subsEvents.forEach(e => {
+        const u = userMap.get(e.userId)
+        if (!u) return
+        seg.plan[u.plan] = (seg.plan[u.plan] || 0) + 1
+        seg.utmSource[u.utmSource] = (seg.utmSource[u.utmSource] || 0) + 1
+        seg.country[u.country] = (seg.country[u.country] || 0) + 1
+      })
+      const cohortMap = {}
+      users.forEach(u => {
+        const created = new Date(u.createdAt + 'T00:00:00Z')
+        const last = new Date(u.lastActiveAt + 'T00:00:00Z')
+        const week = getISOWeek(created)
+        const diff = (last - created) / 86400000
+        if (!cohortMap[week]) cohortMap[week] = { total: 0, d7: 0, d14: 0, d28: 0 }
+        cohortMap[week].total++
+        if (diff >= 7) cohortMap[week].d7++
+        if (diff >= 14) cohortMap[week].d14++
+        if (diff >= 28) cohortMap[week].d28++
+      })
+      const cohortWeeks = Object.keys(cohortMap).sort()
+      const cohorts = cohortWeeks.map(week => {
+        const c = cohortMap[week]
+        return {
+          week,
+          d7: c.total ? (c.d7 / c.total) * 100 : 0,
+          d14: c.total ? (c.d14 / c.total) * 100 : 0,
+          d28: c.total ? (c.d28 / c.total) * 100 : 0
+        }
+      })
+      const deviceCounts = {}
+      const osCounts = {}
+      const browserCounts = {}
+      users.forEach(u => {
+        deviceCounts[u.device] = (deviceCounts[u.device] || 0) + 1
+        osCounts[u.os] = (osCounts[u.os] || 0) + 1
+        browserCounts[u.browser] = (browserCounts[u.browser] || 0) + 1
+      })
+      const sum = obj => Object.values(obj).reduce((a, b) => a + b, 0)
+      const pct = obj => {
+        const total = sum(obj) || 1
+        return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, (v / total) * 100]))
+      }
+      const platforms = { device: pct(deviceCounts), os: pct(osCounts), browser: pct(browserCounts) }
+      const createdCounts = {}
+      users.forEach(u => {
+        createdCounts[u.createdAt] = (createdCounts[u.createdAt] || 0) + 1
+      })
+      const createdDates = Object.keys(createdCounts).sort()
+      let cumUsers = 0
+      const cumulativeUsers = createdDates.map(d => {
+        cumUsers += createdCounts[d]
+        return { date: d, count: cumUsers }
+      })
+      setData({
+        dates: allDates,
+        dau,
+        wau,
+        mau,
+        sma7,
+        newUsers,
+        returningUsers,
+        conversion,
+        errorRate,
+        sessions,
+        visits,
+        signups,
+        logins,
+        loginsByWeekday,
+        errorsByCode,
+        stickiness,
+        subsPerDay,
+        funnelTotals,
+        pareto,
+        errorPageTop,
+        seg,
+        cohorts,
+        platforms,
+        cumulativeUsers
+      })
+    })
+  }, [])
+  return data
+}
+

--- a/src/urlTree.json
+++ b/src/urlTree.json
@@ -7,6 +7,17 @@
     "children": [
       { "path": "/admin/login", "name": "Login", "children": [] },
       { "path": "/admin/logout", "name": "Logout", "children": [] },
+      { "path": "/admin/dashboard", "name": "Dashboard", "children": [] },
+      {
+        "path": "/admin/graph",
+        "name": "Graph",
+        "children": [
+          { "path": "/admin/graph/growth", "name": "Growth", "children": [] },
+          { "path": "/admin/graph/engagement", "name": "Engagement", "children": [] },
+          { "path": "/admin/graph/reliability", "name": "Reliability", "children": [] },
+          { "path": "/admin/graph/revenue", "name": "Revenue", "children": [] }
+        ]
+      },
       {
         "path": "/admin/charts",
         "name": "Charts",


### PR DESCRIPTION
## Summary
- add admin dashboard with mini charts linking to growth, engagement, reliability and revenue analytics
- implement four detailed analytics pages powered by shared metrics hook
- update navigation tree, docs and release notes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b281c15dec832e8af1a770cc3837fc