### PR TITLE
feat: add admin analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # ACP+Charts now
-Current version: 0.0.51
+Current version: 0.0.52
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
 - Admin login at `/admin/login` using env credentials
-- Admin access to dashboard, charts, and UI demos of 30 forms and 30 hashtags
+- Admin analytics dashboard with linked growth, engagement, reliability and revenue charts
+- Admin access to charts and UI demos of 30 forms and 30 hashtags
 - Logout at `/admin/logout` with redirect for unauthenticated routes
 - Return to originally requested admin page after login
 - Public pages use a collapsible sidebar with icon tooltips and home link
@@ -110,6 +111,13 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+
+18. Аналитика
+ - [x] 18.1 Добавить /admin/dashboard с мини-графиками
+ - [x] 18.2 Добавить /admin/graph/growth
+ - [x] 18.3 Добавить /admin/graph/engagement
+ - [x] 18.4 Добавить /admin/graph/reliability
+ - [x] 18.5 Добавить /admin/graph/revenue
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1327,6 +1327,28 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added analytics dashboard and graph pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены дашборд и страницы графиков",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2545,6 +2567,28 @@
           "weight": 30,
           "type": "refactor",
           "scope": "navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added analytics dashboard and graph pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены дашборд и страницы графиков",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
         }
       ]
     }

--- a/src/admin/app/metrics.js
+++ b/src/admin/app/metrics.js
@@ -1,0 +1,260 @@
+import { useState, useEffect } from 'react'
+
+function toDay(dateStr) {
+  return new Date(dateStr).toISOString().slice(0, 10)
+}
+
+function daysInRange(start, end) {
+  const days = []
+  let cur = new Date(start)
+  const endDate = new Date(end)
+  while (cur <= endDate) {
+    days.push(cur.toISOString().slice(0, 10))
+    cur.setUTCDate(cur.getUTCDate() + 1)
+  }
+  return days
+}
+
+export function useMetrics() {
+  const [metrics, setMetrics] = useState(null)
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/mocks/events.json').then(r => r.json()),
+      fetch('/mocks/activity.json').then(r => r.json()),
+      fetch('/mocks/users.json').then(r => r.json())
+    ]).then(([events, activity, users]) => {
+      const data = computeMetrics(events, activity, users)
+      setMetrics(data)
+    })
+  }, [])
+
+  return metrics
+}
+
+function computeMetrics(events, activity, users) {
+  const eventDays = events.map(e => toDay(e.ts))
+  const activityDays = activity.map(a => a.date)
+  const allDays = daysInRange(
+    eventDays.concat(activityDays).sort()[0],
+    eventDays.concat(activityDays).sort().slice(-1)[0]
+  )
+
+  const eventsByDay = {}
+  events.forEach(e => {
+    const d = toDay(e.ts)
+    ;(eventsByDay[d] ||= []).push(e)
+  })
+
+  const activityByDay = {}
+  activity.forEach(a => {
+    activityByDay[a.date] = a
+  })
+
+  allDays.forEach(d => {
+    if (!activityByDay[d])
+      activityByDay[d] = {
+        date: d,
+        visits: 0,
+        signups: 0,
+        logins: 0,
+        sessions: 0,
+        errors: 0,
+        conversion: 0,
+        errorsByCode: {}
+      }
+    if (!eventsByDay[d]) eventsByDay[d] = []
+  })
+
+  const dau = allDays.map(d => new Set(eventsByDay[d].map(e => e.userId)).size)
+
+  const userFirstDay = {}
+  events.forEach(e => {
+    const d = toDay(e.ts)
+    if (!userFirstDay[e.userId] || userFirstDay[e.userId] > d)
+      userFirstDay[e.userId] = d
+  })
+
+  const wau = allDays.map((d, idx) => {
+    const start = Math.max(0, idx - 6)
+    const ids = new Set()
+    for (let i = start; i <= idx; i++) {
+      eventsByDay[allDays[i]].forEach(e => ids.add(e.userId))
+    }
+    return ids.size
+  })
+
+  const mau = allDays.map((d, idx) => {
+    const start = Math.max(0, idx - 29)
+    const ids = new Set()
+    for (let i = start; i <= idx; i++) {
+      eventsByDay[allDays[i]].forEach(e => ids.add(e.userId))
+    }
+    return ids.size
+  })
+
+  const dauSMA7 = dau.map((_, idx) => {
+    const start = Math.max(0, idx - 6)
+    const slice = dau.slice(start, idx + 1)
+    const sum = slice.reduce((a, b) => a + b, 0)
+    return +(sum / slice.length).toFixed(2)
+  })
+
+  const newReturning = allDays.map(d => {
+    const users = Array.from(new Set(eventsByDay[d].map(e => e.userId)))
+    let n = 0
+    users.forEach(u => {
+      if (userFirstDay[u] === d) n++
+    })
+    return { new: n, returning: users.length - n }
+  })
+
+  const visits = allDays.map(d => activityByDay[d].visits)
+  const signups = allDays.map(d => activityByDay[d].signups)
+  const logins = allDays.map(d => activityByDay[d].logins)
+
+  const sessions = allDays.map(d => activityByDay[d].sessions)
+  const conversion = allDays.map(d => {
+    const a = activityByDay[d]
+    return a.visits ? +(a.signups / a.visits).toFixed(3) : 0
+  })
+  const errorRate = allDays.map(d => {
+    const a = activityByDay[d]
+    return a.sessions ? +(a.errors / a.sessions).toFixed(3) : 0
+  })
+
+  const stickiness = allDays.map((d, idx) => (mau[idx] ? +(dau[idx] / mau[idx]).toFixed(3) : 0))
+
+  const loginsByWeekday = Array(7).fill(0)
+  events
+    .filter(e => e.type === 'login')
+    .forEach(e => {
+      const wd = new Date(e.ts).getUTCDay()
+      loginsByWeekday[wd]++
+    })
+
+  const errorsByCodePerDay = {}
+  const codeTotals = {}
+  allDays.forEach(d => {
+    const codes = activityByDay[d].errorsByCode
+    errorsByCodePerDay[d] = {}
+    Object.keys(codes).forEach(code => {
+      errorsByCodePerDay[d][code] = codes[code]
+      codeTotals[code] = (codeTotals[code] || 0) + codes[code]
+    })
+  })
+
+  const errorEventsByPage = {}
+  events
+    .filter(e => e.type === 'error')
+    .forEach(e => {
+      errorEventsByPage[e.page] = (errorEventsByPage[e.page] || 0) + 1
+    })
+  const errorPagesTop = Object.entries(errorEventsByPage)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+
+  const funnelTypes = ['visit', 'signup', 'verify', 'login', 'first_action', 'subscribe']
+  const funnelTotals = {}
+  funnelTypes.forEach(t => {
+    funnelTotals[t] = events.filter(e => e.type === t).length
+  })
+
+  const subsPerDayMap = {}
+  events
+    .filter(e => e.type === 'subscribe')
+    .forEach(e => {
+      const d = toDay(e.ts)
+      subsPerDayMap[d] = (subsPerDayMap[d] || 0) + 1
+    })
+  const subsPerDay = allDays.map(d => subsPerDayMap[d] || 0)
+
+  const subsSegments = { plan: {}, utmSource: {}, country: {} }
+  events
+    .filter(e => e.type === 'subscribe')
+    .forEach(e => {
+      const u = users.find(u => u.id === e.userId) || {}
+      ;['plan', 'utmSource', 'country'].forEach(k => {
+        const val = u[k] || 'unknown'
+        subsSegments[k][val] = (subsSegments[k][val] || 0) + 1
+      })
+    })
+
+  function startOfWeek(dateStr) {
+    const d = new Date(dateStr)
+    const day = d.getUTCDay()
+    const diff = (day + 6) % 7
+    d.setUTCDate(d.getUTCDate() - diff)
+    return d.toISOString().slice(0, 10)
+  }
+
+  const retentionMap = {}
+  users.forEach(u => {
+    const week = startOfWeek(u.createdAt)
+    ;(retentionMap[week] ||= { total: 0, d7: 0, d14: 0, d28: 0 })
+    retentionMap[week].total++
+    const created = new Date(u.createdAt)
+    const last = new Date(u.lastActiveAt)
+    if (last - created >= 7 * 864e5) retentionMap[week].d7++
+    if (last - created >= 14 * 864e5) retentionMap[week].d14++
+    if (last - created >= 28 * 864e5) retentionMap[week].d28++
+  })
+  const retention = Object.entries(retentionMap).map(([week, v]) => ({
+    week,
+    d7: +(v.d7 / v.total).toFixed(2),
+    d14: +(v.d14 / v.total).toFixed(2),
+    d28: +(v.d28 / v.total).toFixed(2)
+  }))
+
+  const platform = { device: {}, os: {}, browser: {} }
+  users.forEach(u => {
+    ;['device', 'os', 'browser'].forEach(k => {
+      const val = u[k] || 'unknown'
+      platform[k][val] = (platform[k][val] || 0) + 1
+    })
+  })
+
+  const signupsPerDay = allDays.map(d => activityByDay[d].signups)
+
+  const cumulativeUsers = (() => {
+    const dates = users.map(u => u.createdAt).sort()
+    if (!dates.length) return []
+    const days = daysInRange(dates[0], dates[dates.length - 1])
+    let total = 0
+    const counts = days.map(d => {
+      users.forEach(u => {
+        if (u.createdAt === d) total++
+      })
+      return total
+    })
+    return { days, counts }
+  })()
+
+  return {
+    days: allDays,
+    dau,
+    wau,
+    mau,
+    dauSMA7,
+    newReturning,
+    visits,
+    signups,
+    logins,
+    sessions,
+    conversion,
+    errorRate,
+    stickiness,
+    loginsByWeekday,
+    errorsByCodePerDay,
+    codeTotals,
+    errorPagesTop,
+    funnelTotals,
+    subsPerDay,
+    subsSegments,
+    retention,
+    platform,
+    signupsPerDay,
+    cumulativeUsers
+  }
+}
+

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -7,11 +7,29 @@ import AdminChartsUsersExplainPage from '../pages/adminChartsUsersExplainPage.js
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+import AdminDashboardPage from '../pages/adminDashboardPage.jsx'
+import AdminGraphPage from '../pages/adminGraphPage.jsx'
+import AdminGraphGrowthPage from '../pages/adminGraphGrowthPage.jsx'
+import AdminGraphEngagementPage from '../pages/adminGraphEngagementPage.jsx'
+import AdminGraphReliabilityPage from '../pages/adminGraphReliabilityPage.jsx'
+import AdminGraphRevenuePage from '../pages/adminGraphRevenuePage.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
   { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
   { index: true, element: <AdminPage />, label: 'Home' },
+  { path: 'dashboard', element: <AdminDashboardPage />, label: 'Dashboard' },
+  {
+    path: 'graph',
+    element: <AdminGraphPage />,
+    label: 'Graph',
+    children: [
+      { path: 'growth', element: <AdminGraphGrowthPage />, label: 'Growth' },
+      { path: 'engagement', element: <AdminGraphEngagementPage />, label: 'Engagement' },
+      { path: 'reliability', element: <AdminGraphReliabilityPage />, label: 'Reliability' },
+      { path: 'revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' },
+    ]
+  },
   {
     path: 'charts',
     element: <AdminChartsPage />,

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { useMetrics } from '../app/metrics.js'
+
+ChartJS.register(...registerables)
+
+function Tile({ to, chart, caption }) {
+  return (
+    <div style={{ width: '200px', margin: '1rem' }}>
+      <Link to={to}>{chart}</Link>
+      <p style={{ fontSize: '0.8rem' }}>{caption}</p>
+    </div>
+  )
+}
+
+export default function AdminDashboardPage() {
+  const title = 'Admin Dashboard'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const metrics = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!metrics) return null
+
+  const dataDays = metrics.days
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        <Tile
+          to="/admin/graph/growth"
+          chart={<Line data={{ labels: dataDays, datasets: [{ label: 'DAU', data: metrics.dau, borderColor: 'blue', fill: false }] }} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } }, elements: { point: { radius: 0 } } }} />}
+          caption="Source: events, Formula: distinct userId per day, Period: full"
+        />
+        <Tile
+          to="/admin/graph/engagement"
+          chart={<Line data={{ labels: dataDays, datasets: [{ label: 'Conversion', data: metrics.conversion, borderColor: 'green', fill: false }] }} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } }, elements: { point: { radius: 0 } } }} />}
+          caption="Source: activity, Formula: signups/visits, Period: full"
+        />
+        <Tile
+          to="/admin/graph/reliability"
+          chart={<Line data={{ labels: dataDays, datasets: [{ label: 'Error rate', data: metrics.errorRate, borderColor: 'red', fill: false }] }} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } }, elements: { point: { radius: 0 } } }} />}
+          caption="Source: activity, Formula: errors/sessions, Period: full"
+        />
+        <Tile
+          to="/admin/graph/revenue"
+          chart={<Bar data={{ labels: dataDays, datasets: [{ label: 'Subs', data: metrics.subsPerDay, backgroundColor: 'orange' }] }} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }} />}
+          caption="Source: events, Formula: count subscribe, Period: full"
+        />
+      </div>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -1,0 +1,131 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Bar, Line } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { useMetrics } from '../app/metrics.js'
+
+ChartJS.register(...registerables)
+
+function Caption({ title, goal, source, formula }) {
+  return (
+    <p style={{ fontSize: '0.9rem' }}>
+      <strong>{title}</strong><br />Goal: {goal}<br />Source: {source}<br />Formula: {formula}<br />Period: full
+    </p>
+  )
+}
+
+export default function AdminGraphEngagementPage() {
+  const title = 'Engagement Graphs'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const metrics = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!metrics) return null
+
+  const platformKeys = Array.from(
+    new Set([
+      ...Object.keys(metrics.platform.device),
+      ...Object.keys(metrics.platform.os),
+      ...Object.keys(metrics.platform.browser)
+    ])
+  )
+
+  function platformData(attr) {
+    const obj = metrics.platform[attr]
+    const total = Object.values(obj).reduce((a, b) => a + b, 0) || 1
+    return Object.entries(obj).map(([k, v]) => ({ k, v: (v / total) * 100 }))
+  }
+
+  const deviceP = platformData('device')
+  const osP = platformData('os')
+  const browserP = platformData('browser')
+
+  const datasetsPlatform = platformKeys.map(k => ({
+    label: k,
+    data: [
+      deviceP.find(x => x.k === k)?.v || 0,
+      osP.find(x => x.k === k)?.v || 0,
+      browserP.find(x => x.k === k)?.v || 0
+    ],
+    stack: 's'
+  }))
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section>
+        <Bar
+          data={{
+            labels: metrics.days,
+            datasets: [
+              { type: 'bar', label: 'Sessions', data: metrics.sessions, backgroundColor: 'rgba(0,0,255,0.3)', yAxisID: 'y' },
+              { type: 'line', label: 'Conversion', data: metrics.conversion, borderColor: 'green', yAxisID: 'y1' }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true, stacked: false }, y1: { beginAtZero: true, position: 'right', min: 0, max: 1 } } }}
+        />
+        <Caption
+          title="Sessions vs Conversion"
+          goal="load vs signup rate"
+          source="activity"
+          formula="signups/visits"
+        />
+      </section>
+      <section>
+        <Line
+          data={{
+            labels: metrics.days,
+            datasets: [
+              { label: 'Stickiness', data: metrics.stickiness, borderColor: 'purple', fill: false },
+              { label: '0.3', data: Array(metrics.days.length).fill(0.3), borderColor: 'red', borderDash: [5, 5], fill: false },
+              { label: '0.5', data: Array(metrics.days.length).fill(0.5), borderColor: 'green', borderDash: [5, 5], fill: false }
+            ]
+          }}
+          options={{ scales: { y: { min: 0, max: 1 } } }}
+        />
+        <Caption
+          title="Stickiness"
+          goal="daily use vs monthly base"
+          source="events"
+          formula="DAU/MAU"
+        />
+      </section>
+      <section>
+        <Bar
+          data={{
+            labels: metrics.retention.map(r => r.week),
+            datasets: [
+              { label: 'd+7', data: metrics.retention.map(r => r.d7 * 100) },
+              { label: 'd+14', data: metrics.retention.map(r => r.d14 * 100) },
+              { label: 'd+28', data: metrics.retention.map(r => r.d28 * 100) }
+            ]
+          }}
+          options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }}
+        />
+        <Caption
+          title="Retention cohorts"
+          goal="weekly user retention"
+          source="users"
+          formula="share active after N days"
+        />
+      </section>
+      <section>
+        <Bar
+          data={{ labels: ['device', 'os', 'browser'], datasets: datasetsPlatform }}
+          options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }}
+        />
+        <Caption
+          title="Platform profile"
+          goal="technology mix"
+          source="users"
+          formula="share of devices/os/browsers"
+        />
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -1,0 +1,105 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { useMetrics } from '../app/metrics.js'
+
+ChartJS.register(...registerables)
+
+function Caption({ title, goal, source, formula }) {
+  return (
+    <p style={{ fontSize: '0.9rem' }}>
+      <strong>{title}</strong><br />Goal: {goal}<br />Source: {source}<br />Formula: {formula}<br />Period: full
+    </p>
+  )
+}
+
+export default function AdminGraphGrowthPage() {
+  const title = 'Growth Graphs'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const metrics = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!metrics) return null
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section>
+        <Line
+          data={{
+            labels: metrics.days,
+            datasets: [
+              { label: 'DAU', data: metrics.dau, borderColor: 'blue', backgroundColor: 'rgba(0,0,255,0.2)', fill: true, stack: 'a' },
+              { label: 'WAU', data: metrics.wau, borderColor: 'green', backgroundColor: 'rgba(0,255,0,0.2)', fill: true, stack: 'a' },
+              { label: 'MAU', data: metrics.mau, borderColor: 'orange', backgroundColor: 'rgba(255,165,0,0.2)', fill: true, stack: 'a' },
+              { label: 'SMA7', data: metrics.dauSMA7, borderColor: 'black', fill: false }
+            ]
+          }}
+        />
+        <Caption
+          title="Active users"
+          goal="compare DAU, WAU, MAU"
+          source="events"
+          formula="distinct users per window"
+        />
+      </section>
+      <section>
+        <Line
+          data={{
+            labels: metrics.days,
+            datasets: [
+              { label: 'New', data: metrics.newReturning.map(d => d.new), borderColor: 'purple', backgroundColor: 'rgba(128,0,128,0.2)', fill: true, stack: 'b' },
+              { label: 'Returning', data: metrics.newReturning.map(d => d.returning), borderColor: 'gray', backgroundColor: 'rgba(128,128,128,0.2)', fill: true, stack: 'b' }
+            ]
+          }}
+        />
+        <Caption
+          title="New vs Returning"
+          goal="share of first-time users"
+          source="events"
+          formula="first event date"
+        />
+      </section>
+      <section>
+        <Line
+          data={{
+            labels: metrics.days,
+            datasets: [
+              { label: 'Visits', data: metrics.visits, borderColor: 'blue', fill: false },
+              { label: 'Signups', data: metrics.signups, borderColor: 'green', fill: false },
+              { label: 'Logins', data: metrics.logins, borderColor: 'orange', fill: false }
+            ]
+          }}
+        />
+        <Caption
+          title="Funnel daily"
+          goal="track visits→signups→logins"
+          source="activity"
+          formula="counts per day"
+        />
+      </section>
+      <section>
+        <Bar
+          data={{
+            labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+            datasets: [
+              { label: 'Logins', data: metrics.loginsByWeekday, backgroundColor: 'teal' }
+            ]
+          }}
+        />
+        <Caption
+          title="Logins by weekday"
+          goal="seasonality"
+          source="events"
+          formula="count logins per weekday"
+        />
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphPage.jsx
+++ b/src/admin/pages/adminGraphPage.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+
+export default function AdminGraphPage() {
+  const title = 'Graphs'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -1,0 +1,121 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { useMetrics } from '../app/metrics.js'
+
+ChartJS.register(...registerables)
+
+function Caption({ title, goal, source, formula }) {
+  return (
+    <p style={{ fontSize: '0.9rem' }}>
+      <strong>{title}</strong><br />Goal: {goal}<br />Source: {source}<br />Formula: {formula}<br />Period: full
+    </p>
+  )
+}
+
+export default function AdminGraphReliabilityPage() {
+  const title = 'Reliability Graphs'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const metrics = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!metrics) return null
+
+  const codes = Object.keys(metrics.codeTotals)
+
+  const pareto = (() => {
+    const entries = Object.entries(metrics.codeTotals).sort((a, b) => b[1] - a[1])
+    let cum = 0
+    const total = entries.reduce((a, b) => a + b[1], 0) || 1
+    const bars = entries.map(([, v]) => v)
+    const line = entries.map(([, v]) => {
+      cum += v
+      return (cum / total) * 100
+    })
+    const labels = entries.map(([code]) => code)
+    return { labels, bars, line }
+  })()
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section>
+        <Line
+          data={{
+            labels: metrics.days,
+            datasets: [
+              { label: 'Error rate', data: metrics.errorRate, borderColor: 'red', fill: false },
+              { label: 'SLO', data: Array(metrics.days.length).fill(0.05), borderColor: 'green', borderDash: [5, 5], fill: false }
+            ]
+          }}
+        />
+        <Caption
+          title="Error rate"
+          goal="stability per session"
+          source="activity"
+          formula="errors/sessions"
+        />
+      </section>
+      <section>
+        <Line
+          data={{
+            labels: metrics.days,
+            datasets: codes.map(code => ({
+              label: code,
+              data: metrics.days.map(d => metrics.errorsByCodePerDay[d][code] || 0),
+              fill: true
+            }))
+          }}
+          options={{ scales: { x: { stacked: true }, y: { stacked: true } } }}
+        />
+        <Caption
+          title="Errors by code"
+          goal="incident structure"
+          source="activity"
+          formula="daily counts per code"
+        />
+      </section>
+      <section>
+        <Bar
+          data={{
+            labels: pareto.labels,
+            datasets: [
+              { type: 'bar', label: 'Errors', data: pareto.bars, backgroundColor: 'orange', yAxisID: 'y' },
+              { type: 'line', label: 'Cum %', data: pareto.line, borderColor: 'blue', yAxisID: 'y1' }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true }, y1: { position: 'right', min: 0, max: 100 } } }}
+        />
+        <Caption
+          title="Pareto codes"
+          goal="80/20 problems"
+          source="activity"
+          formula="cumulative share"
+        />
+      </section>
+      <section>
+        <Bar
+          data={{
+            labels: metrics.errorPagesTop.map(p => p[0]),
+            datasets: [
+              { label: 'Errors', data: metrics.errorPagesTop.map(p => p[1]), backgroundColor: 'teal' }
+            ]
+          }}
+          options={{ indexAxis: 'y' }}
+        />
+        <Caption
+          title="Errors by page"
+          goal="problem pages"
+          source="events"
+          formula="top 10 error pages"
+        />
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -1,0 +1,116 @@
+import { useEffect } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Bar, Line } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { useMetrics } from '../app/metrics.js'
+
+ChartJS.register(...registerables)
+
+function Caption({ title, goal, source, formula }) {
+  return (
+    <p style={{ fontSize: '0.9rem' }}>
+      <strong>{title}</strong><br />Goal: {goal}<br />Source: {source}<br />Formula: {formula}<br />Period: full
+    </p>
+  )
+}
+
+export default function AdminGraphRevenuePage() {
+  const title = 'Revenue Graphs'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const metrics = useMetrics()
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  if (!metrics) return null
+
+  const funnelLabels = ['visit', 'signup', 'verify', 'login', 'first_action', 'subscribe']
+  const subsSegKeys = Array.from(
+    new Set([
+      ...Object.keys(metrics.subsSegments.plan),
+      ...Object.keys(metrics.subsSegments.utmSource),
+      ...Object.keys(metrics.subsSegments.country)
+    ])
+  )
+
+  function segData(attr) {
+    const obj = metrics.subsSegments[attr]
+    const total = Object.values(obj).reduce((a, b) => a + b, 0) || 1
+    return Object.entries(obj).map(([k, v]) => ({ k, v: (v / total) * 100 }))
+  }
+
+  const planP = segData('plan')
+  const utmP = segData('utmSource')
+  const countryP = segData('country')
+
+  const datasetsSeg = subsSegKeys.map(k => ({
+    label: k,
+    data: [
+      planP.find(x => x.k === k)?.v || 0,
+      utmP.find(x => x.k === k)?.v || 0,
+      countryP.find(x => x.k === k)?.v || 0
+    ],
+    stack: 's'
+  }))
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section>
+        <Bar
+          data={{ labels: funnelLabels, datasets: [{ label: 'count', data: funnelLabels.map(l => metrics.funnelTotals[l]), backgroundColor: 'purple' }] }}
+        />
+        <Caption
+          title="Funnel totals"
+          goal="drop at each step"
+          source="events"
+          formula="count of funnel events"
+        />
+      </section>
+      <section>
+        <Bar
+          data={{ labels: ['plan', 'utmSource', 'country'], datasets: datasetsSeg }}
+          options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }}
+        />
+        <Caption
+          title="Subscription segments"
+          goal="distribution"
+          source="events+users"
+          formula="share per plan/utm/country"
+        />
+      </section>
+      <section>
+        <Bar
+          data={{
+            labels: metrics.days,
+            datasets: [
+              { type: 'bar', label: 'Signups', data: metrics.signupsPerDay, backgroundColor: 'rgba(0,0,255,0.3)', yAxisID: 'y' },
+              { type: 'line', label: 'Subscribes', data: metrics.subsPerDay, borderColor: 'green', yAxisID: 'y1' }
+            ]
+          }}
+          options={{ scales: { y: { beginAtZero: true }, y1: { position: 'right', beginAtZero: true } } }}
+        />
+        <Caption
+          title="Signups vs Subscribes"
+          goal="free vs paid"
+          source="activity+events"
+          formula="daily counts"
+        />
+      </section>
+      <section>
+        <Line
+          data={{ labels: metrics.cumulativeUsers.days, datasets: [{ label: 'Users', data: metrics.cumulativeUsers.counts, borderColor: 'blue', fill: false }] }}
+        />
+        <Caption
+          title="Cumulative users"
+          goal="user base growth"
+          source="users"
+          formula="cumulative signups"
+        />
+      </section>
+    </div>
+  )
+}
+

--- a/src/urlTree.json
+++ b/src/urlTree.json
@@ -7,6 +7,17 @@
     "children": [
       { "path": "/admin/login", "name": "Login", "children": [] },
       { "path": "/admin/logout", "name": "Logout", "children": [] },
+      { "path": "/admin/dashboard", "name": "Dashboard", "children": [] },
+      {
+        "path": "/admin/graph",
+        "name": "Graph",
+        "children": [
+          { "path": "/admin/graph/growth", "name": "Growth", "children": [] },
+          { "path": "/admin/graph/engagement", "name": "Engagement", "children": [] },
+          { "path": "/admin/graph/reliability", "name": "Reliability", "children": [] },
+          { "path": "/admin/graph/revenue", "name": "Revenue", "children": [] }
+        ]
+      },
       {
         "path": "/admin/charts",
         "name": "Charts",


### PR DESCRIPTION
## Summary
- add admin dashboard with mini charts linking to growth, engagement, reliability and revenue pages
- implement analytics graph pages using Chart.js with mock data
- document new analytics features and release notes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b281c15dec832e8af1a770cc3837fc