### PR TITLE
feat: add analytics dashboard and graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.51
+Current version: 0.0.52
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -15,6 +15,8 @@ Current version: 0.0.51
 - User and admin sidebars highlight the active link
 - Admin charts with 20 Recharts examples for users data
 - Admin charts with 21 Chart.js examples for users data
+- Admin dashboard with mini charts for growth, engagement, reliability, and revenue
+- Dedicated analytics pages for growth, engagement, reliability, and revenue using mock data
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -110,6 +112,13 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+
+# 18. Analytics dashboard
+  - [x] 18.1 Добавить страницу /admin/dashboard с мини-графиками
+  - [x] 18.2 Добавить страницу /admin/graph/growth с графиками роста
+  - [x] 18.3 Добавить страницу /admin/graph/engagement с графиками вовлеченности
+  - [x] 18.4 Добавить страницу /admin/graph/reliability с графиками надежности
+  - [x] 18.5 Добавить страницу /admin/graph/revenue с графиками выручки
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1327,6 +1327,28 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added analytics dashboard and metric pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены дашборд и страницы метрик",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2545,6 +2567,28 @@
           "weight": 30,
           "type": "refactor",
           "scope": "navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added analytics dashboard and metric pages",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены дашборд и страницы метрик",
+          "weight": 80,
+          "type": "feat",
+          "scope": "analytics"
         }
       ]
     }

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -7,11 +7,21 @@ import AdminChartsUsersExplainPage from '../pages/adminChartsUsersExplainPage.js
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+import AdminDashboardPage from '../pages/adminDashboardPage.jsx'
+import AdminGraphGrowthPage from '../pages/adminGraphGrowthPage.jsx'
+import AdminGraphEngagementPage from '../pages/adminGraphEngagementPage.jsx'
+import AdminGraphReliabilityPage from '../pages/adminGraphReliabilityPage.jsx'
+import AdminGraphRevenuePage from '../pages/adminGraphRevenuePage.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
   { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
   { index: true, element: <AdminPage />, label: 'Home' },
+  { path: 'dashboard', element: <AdminDashboardPage />, label: 'Dashboard' },
+  { path: 'graph/growth', element: <AdminGraphGrowthPage />, label: 'Growth' },
+  { path: 'graph/engagement', element: <AdminGraphEngagementPage />, label: 'Engagement' },
+  { path: 'graph/reliability', element: <AdminGraphReliabilityPage />, label: 'Reliability' },
+  { path: 'graph/revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' },
   {
     path: 'charts',
     element: <AdminChartsPage />,

--- a/src/admin/lib/analytics.js
+++ b/src/admin/lib/analytics.js
@@ -1,0 +1,155 @@
+import { parseISO, addDays, formatISO } from 'date-fns'
+
+function dateKey(ts) {
+  return ts.slice(0, 10)
+}
+
+export function prepareEventMetrics(events) {
+  const byDate = {}
+  const firstSeen = {}
+  const funnel = { visit: 0, signup: 0, verify: 0, login: 0, first_action: 0, subscribe: 0 }
+  const subsPerDay = {}
+  const errorsByPage = {}
+  const loginsByWeekday = { Mon: 0, Tue: 0, Wed: 0, Thu: 0, Fri: 0, Sat: 0, Sun: 0 }
+
+  events.forEach(ev => {
+    const d = dateKey(ev.ts)
+    if (!byDate[d]) byDate[d] = { users: new Set(), events: [] }
+    byDate[d].users.add(ev.userId)
+    byDate[d].events.push(ev)
+    if (funnel[ev.type] !== undefined) funnel[ev.type]++
+    if (ev.type === 'subscribe') subsPerDay[d] = (subsPerDay[d] || 0) + 1
+    if (ev.type === 'error') {
+      errorsByPage[ev.page] = (errorsByPage[ev.page] || 0) + 1
+    }
+    if (ev.type === 'login') {
+      const wd = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][new Date(ev.ts).getUTCDay()]
+      loginsByWeekday[wd] = (loginsByWeekday[wd] || 0) + 1
+    }
+  })
+
+  const dates = Object.keys(byDate).sort()
+  const daily = dates.map(d => ({ date: d, dau: byDate[d].users.size, users: byDate[d].users }))
+
+  daily.forEach((d, i) => {
+    const wauSet = new Set()
+    for (let j = Math.max(0, i - 6); j <= i; j++) daily[j].users.forEach(u => wauSet.add(u))
+    d.wau = wauSet.size
+    const mauSet = new Set()
+    for (let j = Math.max(0, i - 29); j <= i; j++) daily[j].users.forEach(u => mauSet.add(u))
+    d.mau = mauSet.size
+    const slice = daily.slice(Math.max(0, i - 6), i + 1)
+    d.sma7 = slice.reduce((sum, v) => sum + v.dau, 0) / slice.length
+  })
+
+  daily.forEach(d => {
+    let n = 0
+    let r = 0
+    d.users.forEach(u => {
+      if (firstSeen[u]) r++
+      else {
+        firstSeen[u] = d.date
+        n++
+      }
+    })
+    d.newUsers = n
+    d.returning = r
+  })
+
+  const weekdayOrder = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+  const loginsByWeek = weekdayOrder.map(w => ({ day: w, value: loginsByWeekday[w] }))
+
+  const topPages = Object.entries(errorsByPage)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([page, value]) => ({ page, value }))
+
+  return { daily, subsPerDay, funnel, loginsByWeek, errorsByPage: topPages }
+}
+
+export function prepareActivityMetrics(activity) {
+  const daily = activity.map(a => ({
+    date: a.date,
+    sessions: a.sessions,
+    signups: a.signups,
+    visits: a.visits,
+    logins: a.logins,
+    errors: a.errors,
+    errorsByCode: a.errorsByCode || {},
+    conversion: a.visits ? a.signups / a.visits : 0,
+    errorRate: a.sessions ? a.errors / a.sessions : 0
+  }))
+
+  const errorCodes = {}
+  daily.forEach(d => {
+    Object.entries(d.errorsByCode).forEach(([code, val]) => {
+      errorCodes[code] = (errorCodes[code] || 0) + val
+    })
+  })
+
+  return { daily, errorCodes }
+}
+
+export function prepareRetention(users) {
+  const cohorts = {}
+  users.forEach(u => {
+    const created = parseISO(u.createdAt)
+    const weekStart = formatISO(addDays(created, -((created.getUTCDay() + 6) % 7)), { representation: 'date' })
+    if (!cohorts[weekStart]) cohorts[weekStart] = { total: 0, d7: 0, d14: 0, d28: 0 }
+    cohorts[weekStart].total++
+    const last = parseISO(u.lastActiveAt)
+    const diff = (last - created) / 86400000
+    if (diff >= 7) cohorts[weekStart].d7++
+    if (diff >= 14) cohorts[weekStart].d14++
+    if (diff >= 28) cohorts[weekStart].d28++
+  })
+
+  return Object.entries(cohorts)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([week, c]) => ({
+      week,
+      d7: (c.d7 / c.total) * 100,
+      d14: (c.d14 / c.total) * 100,
+      d28: (c.d28 / c.total) * 100
+    }))
+}
+
+export function cumulativeUsers(users) {
+  const counts = {}
+  users.forEach(u => {
+    counts[u.createdAt] = (counts[u.createdAt] || 0) + 1
+  })
+  const dates = Object.keys(counts).sort()
+  let sum = 0
+  return dates.map(d => {
+    sum += counts[d]
+    return { date: d, value: sum }
+  })
+}
+
+export function subscriptionSegments(subEvents, users) {
+  const userMap = {}
+  users.forEach(u => {
+    userMap[u.id] = u
+  })
+  const plan = {}
+  const utm = {}
+  const country = {}
+  subEvents.forEach(ev => {
+    const u = userMap[ev.userId] || {}
+    plan[u.plan] = (plan[u.plan] || 0) + 1
+    utm[u.utmSource] = (utm[u.utmSource] || 0) + 1
+    country[u.country] = (country[u.country] || 0) + 1
+  })
+  const toPct = obj => {
+    const total = Object.values(obj).reduce((a, b) => a + b, 0)
+    return Object.entries(obj).map(([k, v]) => ({ name: k, value: (v / total) * 100 }))
+  }
+  return { plan: toPct(plan), utm: toPct(utm), country: toPct(country) }
+}
+
+export function dateExtent(dates) {
+  if (dates.length === 0) return ''
+  return `${dates[0]} to ${dates[dates.length - 1]}`
+}
+

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { prepareEventMetrics, prepareActivityMetrics, dateExtent } from '../lib/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminDashboardPage() {
+  const title = 'Admin Dashboard'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [events, setEvents] = useState([])
+  const [activity, setActivity] = useState([])
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    fetch('/mocks/events.json').then(r => r.json()).then(setEvents)
+    fetch('/mocks/activity.json').then(r => r.json()).then(setActivity)
+  }, [])
+
+  const eventMetrics = useMemo(() => prepareEventMetrics(events), [events])
+  const activityMetrics = useMemo(() => prepareActivityMetrics(activity), [activity])
+
+  const dauData = useMemo(() => ({
+    labels: eventMetrics.daily.map(d => d.date),
+    datasets: [
+      {
+        label: 'DAU',
+        data: eventMetrics.daily.map(d => d.dau),
+        borderColor: '#8884d8',
+        backgroundColor: 'rgba(136,132,216,0.3)',
+        fill: true,
+        tension: 0.4
+      }
+    ]
+  }), [eventMetrics])
+
+  const conversionData = useMemo(() => ({
+    labels: activityMetrics.daily.map(d => d.date),
+    datasets: [
+      {
+        label: 'Conversion',
+        data: activityMetrics.daily.map(d => d.conversion * 100),
+        borderColor: '#82ca9d',
+        tension: 0.4
+      }
+    ]
+  }), [activityMetrics])
+
+  const errorRateData = useMemo(() => ({
+    labels: activityMetrics.daily.map(d => d.date),
+    datasets: [
+      {
+        label: 'Error rate',
+        data: activityMetrics.daily.map(d => d.errorRate * 100),
+        borderColor: '#ff7300',
+        tension: 0.4
+      }
+    ]
+  }), [activityMetrics])
+
+  const subsData = useMemo(() => {
+    const labels = Object.keys(eventMetrics.subsPerDay).sort()
+    return {
+      labels,
+      datasets: [
+        { label: 'Subscriptions', data: labels.map(l => eventMetrics.subsPerDay[l]), backgroundColor: '#ffc658' }
+      ]
+    }
+  }, [eventMetrics])
+
+  const periodEvents = dateExtent(eventMetrics.daily.map(d => d.date))
+  const periodActivity = dateExtent(activityMetrics.daily.map(d => d.date))
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '1rem' }}>
+        <div>
+          <Link to="/admin/graph/growth">
+            <Line data={dauData} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }} height={100} />
+          </Link>
+          <p>Source: events.json; Formula: daily unique users; Period: {periodEvents}</p>
+        </div>
+        <div>
+          <Link to="/admin/graph/engagement">
+            <Line data={conversionData} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }} height={100} />
+          </Link>
+          <p>Source: activity.json; Formula: signups/visits; Period: {periodActivity}</p>
+        </div>
+        <div>
+          <Link to="/admin/graph/reliability">
+            <Line data={errorRateData} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }} height={100} />
+          </Link>
+          <p>Source: activity.json; Formula: errors/sessions; Period: {periodActivity}</p>
+        </div>
+        <div>
+          <Link to="/admin/graph/revenue">
+            <Bar data={subsData} options={{ plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }} height={100} />
+          </Link>
+          <p>Source: events.json; Formula: count(subscribe); Period: {periodEvents}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { prepareEventMetrics, prepareActivityMetrics, prepareRetention, dateExtent } from '../lib/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminGraphEngagementPage() {
+  const title = 'Engagement metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [events, setEvents] = useState([])
+  const [activity, setActivity] = useState([])
+  const [users, setUsers] = useState([])
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    fetch('/mocks/events.json').then(r => r.json()).then(setEvents)
+    fetch('/mocks/activity.json').then(r => r.json()).then(setActivity)
+    fetch('/mocks/users.json').then(r => r.json()).then(setUsers)
+  }, [])
+
+  const eventMetrics = useMemo(() => prepareEventMetrics(events), [events])
+  const activityMetrics = useMemo(() => prepareActivityMetrics(activity), [activity])
+  const retention = useMemo(() => prepareRetention(users), [users])
+
+  const sessionsConversionData = useMemo(() => ({
+    labels: activityMetrics.daily.map(d => d.date),
+    datasets: [
+      { type: 'bar', label: 'Sessions', data: activityMetrics.daily.map(d => d.sessions), backgroundColor: '#8884d8' },
+      { type: 'line', label: 'Conversion %', data: activityMetrics.daily.map(d => d.conversion * 100), borderColor: '#ff7300', yAxisID: 'y1', tension: 0.4 }
+    ]
+  }), [activityMetrics])
+
+  const stickinessData = useMemo(() => ({
+    labels: eventMetrics.daily.map(d => d.date),
+    datasets: [
+      { label: 'Stickiness', data: eventMetrics.daily.map(d => (d.mau ? d.dau / d.mau : 0)), borderColor: '#82ca9d', tension: 0.4 },
+      { label: '0.3', data: eventMetrics.daily.map(() => 0.3), borderColor: '#ff0000', borderDash: [5, 5], pointRadius: 0 },
+      { label: '0.5', data: eventMetrics.daily.map(() => 0.5), borderColor: '#ff0000', borderDash: [5, 5], pointRadius: 0 }
+    ]
+  }), [eventMetrics])
+
+  const retentionData = useMemo(() => ({
+    labels: retention.map(r => r.week),
+    datasets: [
+      { label: 'd+7', data: retention.map(r => r.d7), backgroundColor: '#8884d8', stack: 'ret' },
+      { label: 'd+14', data: retention.map(r => r.d14), backgroundColor: '#82ca9d', stack: 'ret' },
+      { label: 'd+28', data: retention.map(r => r.d28), backgroundColor: '#ffc658', stack: 'ret' }
+    ]
+  }), [retention])
+
+  const periodActivity = dateExtent(activityMetrics.daily.map(d => d.date))
+  const periodEvents = dateExtent(eventMetrics.daily.map(d => d.date))
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Sessions vs Conversion</h3>
+        <div style={{ height: 300 }}>
+          <Bar
+            data={sessionsConversionData}
+            options={{
+              responsive: true,
+              scales: { y: { beginAtZero: true }, y1: { position: 'right', beginAtZero: true, ticks: { callback: v => `${v}%` } } }
+            }}
+          />
+        </div>
+        <p>Goal: load vs conversion; Source: activity.json; Formula: signups/visits; Period: {periodActivity}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Stickiness (DAU/MAU)</h3>
+        <div style={{ height: 300 }}>
+          <Line data={stickinessData} options={{ responsive: true, scales: { y: { beginAtZero: true, max: 1 } } }} />
+        </div>
+        <p>Goal: product stickiness; Source: events.json; Formula: DAU/MAU; Period: {periodEvents}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Retention cohorts</h3>
+        <div style={{ height: 300 }}>
+          <Bar data={retentionData} options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }} />
+        </div>
+        <p>Goal: cohort retention; Source: users.json; Method: lastActive vs createdAt; Period: all time</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -1,0 +1,87 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { prepareEventMetrics, prepareActivityMetrics, dateExtent } from '../lib/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminGraphGrowthPage() {
+  const title = 'Growth metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [events, setEvents] = useState([])
+  const [activity, setActivity] = useState([])
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    fetch('/mocks/events.json').then(r => r.json()).then(setEvents)
+    fetch('/mocks/activity.json').then(r => r.json()).then(setActivity)
+  }, [])
+
+  const eventMetrics = useMemo(() => prepareEventMetrics(events), [events])
+  const activityMetrics = useMemo(() => prepareActivityMetrics(activity), [activity])
+
+  const labels = eventMetrics.daily.map(d => d.date)
+
+  const dauWauMauData = useMemo(() => ({
+    labels,
+    datasets: [
+      { label: 'DAU', data: eventMetrics.daily.map(d => d.dau), borderColor: '#8884d8', backgroundColor: 'rgba(136,132,216,0.3)', fill: true, stack: 'users', tension: 0.4 },
+      { label: 'WAU', data: eventMetrics.daily.map(d => d.wau), borderColor: '#82ca9d', backgroundColor: 'rgba(130,202,157,0.3)', fill: true, stack: 'users', tension: 0.4 },
+      { label: 'MAU', data: eventMetrics.daily.map(d => d.mau), borderColor: '#ffc658', backgroundColor: 'rgba(255,198,88,0.3)', fill: true, stack: 'users', tension: 0.4 },
+      { label: 'SMA7 DAU', data: eventMetrics.daily.map(d => d.sma7), borderColor: '#ff0000', fill: false, tension: 0.4 }
+    ]
+  }), [eventMetrics, labels])
+
+  const newReturningData = useMemo(() => ({
+    labels,
+    datasets: [
+      { label: 'New', data: eventMetrics.daily.map(d => d.newUsers), borderColor: '#82ca9d', backgroundColor: 'rgba(130,202,157,0.5)', fill: true, stack: 'nr', tension: 0.4 },
+      { label: 'Returning', data: eventMetrics.daily.map(d => d.returning), borderColor: '#8884d8', backgroundColor: 'rgba(136,132,216,0.5)', fill: true, stack: 'nr', tension: 0.4 }
+    ]
+  }), [eventMetrics, labels])
+
+  const funnelLineData = useMemo(() => ({
+    labels: activityMetrics.daily.map(d => d.date),
+    datasets: [
+      { label: 'Visits', data: activityMetrics.daily.map(d => d.visits), borderColor: '#8884d8', tension: 0.4 },
+      { label: 'Signups', data: activityMetrics.daily.map(d => d.signups), borderColor: '#82ca9d', tension: 0.4 },
+      { label: 'Logins', data: activityMetrics.daily.map(d => d.logins), borderColor: '#ffc658', tension: 0.4 }
+    ]
+  }), [activityMetrics])
+
+  const periodEvents = dateExtent(labels)
+  const periodActivity = dateExtent(activityMetrics.daily.map(d => d.date))
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>DAU vs WAU vs MAU with SMA7</h3>
+        <div style={{ height: 300 }}>
+          <Line data={dauWauMauData} options={{ scales: { y: { stacked: true } } }} />
+        </div>
+        <p>Goal: compare active user scales; Source: events.json; Formulas: DAU/WAU/MAU, SMA7; Period: {periodEvents}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>New vs Returning users</h3>
+        <div style={{ height: 300 }}>
+          <Line data={newReturningData} options={{ scales: { y: { stacked: true } } }} />
+        </div>
+        <p>Goal: share of new and returning; Source: events.json; Method: first event defines "new"; Period: {periodEvents}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Visits, Signups, Logins</h3>
+        <div style={{ height: 300 }}>
+          <Line data={funnelLineData} />
+        </div>
+        <p>Goal: funnel dynamics; Source: activity.json; Metrics: daily visits/signups/logins; Period: {periodActivity}</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { prepareEventMetrics, prepareActivityMetrics, dateExtent } from '../lib/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminGraphReliabilityPage() {
+  const title = 'Reliability metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [events, setEvents] = useState([])
+  const [activity, setActivity] = useState([])
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    fetch('/mocks/events.json').then(r => r.json()).then(setEvents)
+    fetch('/mocks/activity.json').then(r => r.json()).then(setActivity)
+  }, [])
+
+  const eventMetrics = useMemo(() => prepareEventMetrics(events), [events])
+  const activityMetrics = useMemo(() => prepareActivityMetrics(activity), [activity])
+
+  const errorRateData = useMemo(() => ({
+    labels: activityMetrics.daily.map(d => d.date),
+    datasets: [
+      { label: 'Error rate', data: activityMetrics.daily.map(d => d.errorRate * 100), borderColor: '#ff7300', tension: 0.4 }
+    ]
+  }), [activityMetrics])
+
+  const codes = useMemo(() => {
+    const set = new Set()
+    activityMetrics.daily.forEach(d => Object.keys(d.errorsByCode).forEach(c => set.add(c)))
+    return Array.from(set).sort()
+  }, [activityMetrics])
+
+  const errorsByCodeData = useMemo(() => ({
+    labels: activityMetrics.daily.map(d => d.date),
+    datasets: codes.map((c, i) => ({
+      label: c,
+      data: activityMetrics.daily.map(d => d.errorsByCode[c] || 0),
+      borderColor: ['#8884d8', '#82ca9d', '#ffc658', '#ff7300'][i % 4],
+      backgroundColor: ['rgba(136,132,216,0.5)','rgba(130,202,157,0.5)','rgba(255,198,88,0.5)','rgba(255,115,0,0.5)'][i % 4],
+      fill: true,
+      stack: 'codes',
+      tension: 0.4
+    }))
+  }), [activityMetrics, codes])
+
+  const paretoData = useMemo(() => {
+    const entries = Object.entries(activityMetrics.errorCodes).sort((a, b) => b[1] - a[1])
+    let cumulative = 0
+    const total = entries.reduce((a, b) => a + b[1], 0)
+    const labels = entries.map(e => e[0])
+    const counts = entries.map(e => e[1])
+    const cumulativePct = entries.map(e => {
+      cumulative += e[1]
+      return (cumulative / total) * 100
+    })
+    return {
+      labels,
+      datasets: [
+        { type: 'bar', label: 'Errors', data: counts, backgroundColor: '#8884d8' },
+        { type: 'line', label: 'Cumulative %', data: cumulativePct, borderColor: '#ff0000', yAxisID: 'y1', tension: 0.4 }
+      ]
+    }
+  }, [activityMetrics])
+
+  const errorsByPageData = useMemo(() => ({
+    labels: eventMetrics.errorsByPage.map(e => e.page),
+    datasets: [
+      { label: 'Errors', data: eventMetrics.errorsByPage.map(e => e.value), backgroundColor: '#82ca9d' }
+    ]
+  }), [eventMetrics])
+
+  const periodActivity = dateExtent(activityMetrics.daily.map(d => d.date))
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Error rate</h3>
+        <div style={{ height: 300 }}>
+          <Line data={errorRateData} />
+        </div>
+        <p>Goal: stability per session; Source: activity.json; Formula: errors/sessions; Period: {periodActivity}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Errors by code</h3>
+        <div style={{ height: 300 }}>
+          <Line data={errorsByCodeData} options={{ scales: { y: { stacked: true } } }} />
+        </div>
+        <p>Goal: incident structure; Source: activity.json; Method: errors grouped by code; Period: {periodActivity}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Pareto of error codes</h3>
+        <div style={{ height: 300 }}>
+          <Bar data={paretoData} options={{ scales: { y1: { position: 'right', beginAtZero: true, max: 100 } } }} />
+        </div>
+        <p>Goal: 80/20 of problems; Source: activity.json; Method: cumulative percent; Period: {periodActivity}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Errors by page</h3>
+        <div style={{ height: 300 }}>
+          <Bar data={errorsByPageData} options={{ indexAxis: 'y' }} />
+        </div>
+        <p>Goal: problematic pages; Source: events.json; Metric: error events per page; Period: {periodActivity}</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Chart as ChartJS, registerables } from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import AuthMessage from '../app/authMessage.jsx'
+import { prepareEventMetrics, prepareActivityMetrics, cumulativeUsers, subscriptionSegments, dateExtent } from '../lib/analytics.js'
+
+ChartJS.register(...registerables)
+
+export default function AdminGraphRevenuePage() {
+  const title = 'Revenue metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [events, setEvents] = useState([])
+  const [activity, setActivity] = useState([])
+  const [users, setUsers] = useState([])
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    fetch('/mocks/events.json').then(r => r.json()).then(setEvents)
+    fetch('/mocks/activity.json').then(r => r.json()).then(setActivity)
+    fetch('/mocks/users.json').then(r => r.json()).then(setUsers)
+  }, [])
+
+  const eventMetrics = useMemo(() => prepareEventMetrics(events), [events])
+  const activityMetrics = useMemo(() => prepareActivityMetrics(activity), [activity])
+  const cumUsers = useMemo(() => cumulativeUsers(users), [users])
+  const segments = useMemo(() => {
+    const subs = events.filter(e => e.type === 'subscribe')
+    return subscriptionSegments(subs, users)
+  }, [events, users])
+
+  const funnelData = useMemo(() => ({
+    labels: Object.keys(eventMetrics.funnel),
+    datasets: [
+      { label: 'Count', data: Object.values(eventMetrics.funnel), backgroundColor: '#8884d8' }
+    ]
+  }), [eventMetrics])
+
+  const signupsSubsData = useMemo(() => {
+    const labels = activityMetrics.daily.map(d => d.date)
+    return {
+      labels,
+      datasets: [
+        { type: 'bar', label: 'Signups', data: activityMetrics.daily.map(d => d.signups), backgroundColor: '#8884d8' },
+        { type: 'line', label: 'Subscriptions', data: labels.map(l => eventMetrics.subsPerDay[l] || 0), borderColor: '#ff7300', yAxisID: 'y1', tension: 0.4 }
+      ]
+    }
+  }, [activityMetrics, eventMetrics])
+
+  const cumulativeUsersData = useMemo(() => ({
+    labels: cumUsers.map(c => c.date),
+    datasets: [
+      { label: 'Users', data: cumUsers.map(c => c.value), borderColor: '#82ca9d', tension: 0.4 }
+    ]
+  }), [cumUsers])
+
+  const segmentData = useMemo(() => {
+    const groups = ['Plan', 'UTM', 'Country']
+    const datasets = []
+    ;['plan', 'utm', 'country'].forEach((key, idx) => {
+      segments[key].forEach(seg => {
+        let ds = datasets.find(d => d.label === seg.name)
+        if (!ds) {
+          ds = { label: seg.name, data: Array(3).fill(0), backgroundColor: ['#8884d8', '#82ca9d', '#ffc658', '#ff7300'][datasets.length % 4] }
+          datasets.push(ds)
+        }
+        ds.data[idx] = seg.value
+      })
+    })
+    return { labels: groups, datasets }
+  }, [segments])
+
+  const periodActivity = dateExtent(activityMetrics.daily.map(d => d.date))
+  const periodUsers = dateExtent(cumUsers.map(c => c.date))
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Funnel totals</h3>
+        <div style={{ height: 300 }}>
+          <Bar data={funnelData} />
+        </div>
+        <p>Goal: drop per step; Source: events.json; Method: count by step; Period: {periodActivity}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Subscription segments</h3>
+        <div style={{ height: 300 }}>
+          <Bar data={segmentData} options={{ scales: { x: { stacked: true }, y: { stacked: true, max: 100 } } }} />
+        </div>
+        <p>Goal: segment shares; Source: events+users; Method: subscription distribution; Period: {periodActivity}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Signups vs Subscribes</h3>
+        <div style={{ height: 300 }}>
+          <Bar data={signupsSubsData} options={{ scales: { y1: { position: 'right', beginAtZero: true } } }} />
+        </div>
+        <p>Goal: inflow vs paid conversions; Source: activity+events; Method: signups vs subscribe per day; Period: {periodActivity}</p>
+      </section>
+      <section style={{ marginBottom: '3rem' }}>
+        <h3>Cumulative users</h3>
+        <div style={{ height: 300 }}>
+          <Line data={cumulativeUsersData} />
+        </div>
+        <p>Goal: user base growth; Source: users.json; Method: cumulative count; Period: {periodUsers}</p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/urlTree.json
+++ b/src/urlTree.json
@@ -7,6 +7,11 @@
     "children": [
       { "path": "/admin/login", "name": "Login", "children": [] },
       { "path": "/admin/logout", "name": "Logout", "children": [] },
+      { "path": "/admin/dashboard", "name": "Dashboard", "children": [] },
+      { "path": "/admin/graph/growth", "name": "Growth", "children": [] },
+      { "path": "/admin/graph/engagement", "name": "Engagement", "children": [] },
+      { "path": "/admin/graph/reliability", "name": "Reliability", "children": [] },
+      { "path": "/admin/graph/revenue", "name": "Revenue", "children": [] },
       {
         "path": "/admin/charts",
         "name": "Charts",


### PR DESCRIPTION
## Summary
- build admin dashboard with mini metric charts linking to detailed pages
- implement growth, engagement, reliability and revenue analytics with Chart.js
- document analytics feature and bump version to 0.0.52

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b281c15dec832e8af1a770cc3837fc