### PR TITLE
feat: add admin analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ACP+Charts now
-Current version: 0.0.51
+Current version: 0.0.52
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
 - Admin login at `/admin/login` using env credentials
-- Admin access to dashboard, charts, and UI demos of 30 forms and 30 hashtags
+- Admin access to dashboard, analytics graphs, and UI demos of 30 forms and 30 hashtags
 - Logout at `/admin/logout` with redirect for unauthenticated routes
 - Return to originally requested admin page after login
 - Public pages use a collapsible sidebar with icon tooltips and home link
@@ -15,6 +15,8 @@ Current version: 0.0.51
 - User and admin sidebars highlight the active link
 - Admin charts with 20 Recharts examples for users data
 - Admin charts with 21 Chart.js examples for users data
+- Admin dashboard with mini charts for growth, engagement, reliability, and revenue
+- Detailed analytics pages at `/admin/graph/*` for growth, engagement, reliability, and revenue
 
 # ACP+Charts сomming soon
 ACP+Charts will grow into an admin dashboard that visualizes application metrics with interactive charts. Administrators will be able to monitor key indicators, manage data, and explore analytics through a responsive web interface built with React and Vite. The repository currently includes placeholder pages while chart components are under active development.
@@ -42,6 +44,8 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 3.3 Исправить невидимые графики на /admin/charts/users/recharts.
   - [x] 3.4 Пронумеровать варианты графиков в заголовках на /admin/charts/users/recharts.
   - [x] 3.5 Создать страницу /admin/charts/users/explain и описать ключи из users.json.
+  - [x] 3.6 Добавить страницу /admin/dashboard с мини-графиками.
+  - [x] 3.7 Реализовать страницы /admin/graph/growth, /admin/graph/engagement, /admin/graph/reliability, /admin/graph/revenue с реальными графиками и подписями.
 
 6. Удобства
  - [x] 6.1 Изучить release-notes-howto.md. Создать файл release-notes.json и начать его вести. Указать в readme правила по ведению release-notes.json для каждого раза.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1327,6 +1327,28 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added admin dashboard and metric graphs",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены админский дашборд и аналитические графики",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2545,6 +2567,28 @@
           "weight": 30,
           "type": "refactor",
           "scope": "navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.52",
+      "date": "2025-08-29",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added admin dashboard and metric graphs",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены админский дашборд и аналитические графики",
+          "weight": 70,
+          "type": "feat",
+          "scope": "analytics"
         }
       ]
     }

--- a/src/admin/app/chartSetup.js
+++ b/src/admin/app/chartSetup.js
@@ -1,0 +1,4 @@
+import { Chart as ChartJS, registerables } from 'chart.js'
+import zoomPlugin from 'chartjs-plugin-zoom'
+ChartJS.register(...registerables, zoomPlugin)
+export { ChartJS }

--- a/src/admin/app/metrics.js
+++ b/src/admin/app/metrics.js
@@ -1,0 +1,228 @@
+
+function formatDate(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function dateRange(start, end) {
+  const res = []
+  const d = new Date(start)
+  const e = new Date(end)
+  while (d <= e) {
+    res.push(formatDate(d))
+    d.setDate(d.getDate() + 1)
+  }
+  return res
+}
+
+export async function loadMetrics() {
+  const [events, activity, users] = await Promise.all([
+    fetch('/mocks/events.json').then(r => r.json()),
+    fetch('/mocks/activity.json').then(r => r.json()),
+    fetch('/mocks/users.json').then(r => r.json())
+  ])
+
+  const eventDates = events.map(e => e.ts.slice(0, 10))
+  const activityDates = activity.map(a => a.date)
+  const minDate = [ ...eventDates, ...activityDates ].sort()[0]
+  const maxDate = [ ...eventDates, ...activityDates ].sort().slice(-1)[0]
+  const dates = dateRange(minDate, maxDate)
+
+  const eventsByDate = {}
+  events.forEach(e => {
+    const d = e.ts.slice(0, 10)
+    if (!eventsByDate[d]) eventsByDate[d] = []
+    eventsByDate[d].push(e)
+  })
+
+  const activityByDate = {}
+  activity.forEach(a => {
+    activityByDate[a.date] = a
+  })
+
+  const daily = []
+  const seenUsers = new Set()
+  dates.forEach(date => {
+    const dayEvents = eventsByDate[date] || []
+    const dauUsers = new Set(dayEvents.map(e => e.userId))
+    const dau = dauUsers.size
+    let newUsers = 0
+    let returningUsers = 0
+    dauUsers.forEach(u => {
+      if (seenUsers.has(u)) returningUsers++
+      else {
+        newUsers++
+        seenUsers.add(u)
+      }
+    })
+    daily.push({ date, dau, newUsers, returningUsers })
+  })
+
+  // WAU, MAU, SMA7
+  dates.forEach((date, i) => {
+    const start7 = Math.max(0, i - 6)
+    const wauSet = new Set()
+    for (let j = start7; j <= i; j++) {
+      (eventsByDate[dates[j]] || []).forEach(e => wauSet.add(e.userId))
+    }
+    daily[i].wau = wauSet.size
+
+    const start30 = Math.max(0, i - 29)
+    const mauSet = new Set()
+    for (let j = start30; j <= i; j++) {
+      (eventsByDate[dates[j]] || []).forEach(e => mauSet.add(e.userId))
+    }
+    daily[i].mau = mauSet.size
+
+    let sum = 0
+    let count = 0
+    for (let j = start7; j <= i; j++) {
+      sum += daily[j].dau
+      count++
+    }
+    daily[i].sma7 = count ? sum / count : 0
+  })
+
+  // activity metrics
+  daily.forEach(d => {
+    const a = activityByDate[d.date] || {}
+    d.visits = a.visits || 0
+    d.signups = a.signups || 0
+    d.logins = a.logins || 0
+    d.sessions = a.sessions || 0
+    d.errors = a.errors || 0
+    d.conversion = a.conversion || 0
+    d.conversion_calc = d.visits ? d.signups / d.visits : 0
+    d.error_rate = d.sessions ? d.errors / d.sessions : 0
+    d.errorsByCode = a.errorsByCode || {}
+  })
+
+  // subs per day
+  daily.forEach(d => {
+    const subs = (eventsByDate[d.date] || []).filter(e => e.type === 'subscribe')
+    d.subs = subs.length
+  })
+
+  // logins by weekday
+  const loginsByWeekday = Array(7).fill(0)
+  events.filter(e => e.type === 'login').forEach(e => {
+    const wd = new Date(e.ts).getUTCDay() // 0 Sun
+    const idx = (wd + 6) % 7 // make Monday=0
+    loginsByWeekday[idx]++
+  })
+
+  // error codes totals
+  const errorTotals = {}
+  activity.forEach(a => {
+    Object.entries(a.errorsByCode || {}).forEach(([code, val]) => {
+      errorTotals[code] = (errorTotals[code] || 0) + val
+    })
+  })
+
+  // errors by page
+  const errorPages = {}
+  events.filter(e => e.type === 'error').forEach(e => {
+    errorPages[e.page] = (errorPages[e.page] || 0) + 1
+  })
+  const errorPagesTop = Object.entries(errorPages)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+
+  // active users last 30 days
+  const activeIds = new Set()
+  const startIdx = Math.max(0, dates.length - 30)
+  for (let i = startIdx; i < dates.length; i++) {
+    (eventsByDate[dates[i]] || []).forEach(e => activeIds.add(e.userId))
+  }
+  const userMap = {}
+  users.forEach(u => {
+    userMap[u.id] = u
+  })
+  const profileDist = { device: {}, os: {}, browser: {} }
+  activeIds.forEach(id => {
+    const u = userMap[id]
+    if (!u) return
+    profileDist.device[u.device] = (profileDist.device[u.device] || 0) + 1
+    profileDist.os[u.os] = (profileDist.os[u.os] || 0) + 1
+    profileDist.browser[u.browser] = (profileDist.browser[u.browser] || 0) + 1
+  })
+
+  // retention cohorts
+  function weekStart(dateStr) {
+    const d = new Date(dateStr)
+    const day = d.getUTCDay()
+    const diff = (day === 0 ? -6 : 1) - day
+    d.setDate(d.getDate() + diff)
+    return formatDate(d)
+  }
+  const cohorts = {}
+  users.forEach(u => {
+    const cohort = weekStart(u.createdAt)
+    if (!cohorts[cohort]) cohorts[cohort] = []
+    cohorts[cohort].push(u)
+  })
+  const retention = Object.entries(cohorts).map(([cohort, arr]) => {
+    const total = arr.length
+    let r7 = 0, r14 = 0, r28 = 0
+    arr.forEach(u => {
+      const created = new Date(u.createdAt)
+      const last = new Date(u.lastActiveAt)
+      if (last - created >= 7 * 86400000) r7++
+      if (last - created >= 14 * 86400000) r14++
+      if (last - created >= 28 * 86400000) r28++
+    })
+    return {
+      cohort,
+      d7: total ? r7 / total : 0,
+      d14: total ? r14 / total : 0,
+      d28: total ? r28 / total : 0
+    }
+  })
+  retention.sort((a, b) => a.cohort.localeCompare(b.cohort))
+
+  // funnel totals
+  const steps = ['visit', 'signup', 'verify', 'login', 'first_action', 'subscribe']
+  const funnel = {}
+  steps.forEach(s => {
+    funnel[s] = events.filter(e => e.type === s).length
+  })
+
+  // subscription segments
+  const subsEvents = events.filter(e => e.type === 'subscribe')
+  const seg = { plan: {}, utmSource: {}, country: {} }
+  subsEvents.forEach(e => {
+    const u = userMap[e.userId]
+    if (!u) return
+    seg.plan[u.plan] = (seg.plan[u.plan] || 0) + 1
+    seg.utmSource[u.utmSource] = (seg.utmSource[u.utmSource] || 0) + 1
+    seg.country[u.country] = (seg.country[u.country] || 0) + 1
+  })
+
+  // cumulative users
+  const userDates = users.map(u => u.createdAt)
+  const minUserDate = userDates.sort()[0]
+  const maxUserDate = userDates.slice(-1)[0]
+  const userRange = dateRange(minUserDate, maxUserDate)
+  const cumulativeUsers = []
+  let running = 0
+  const createdMap = {}
+  users.forEach(u => {
+    createdMap[u.createdAt] = (createdMap[u.createdAt] || 0) + 1
+  })
+  userRange.forEach(d => {
+    running += createdMap[d] || 0
+    cumulativeUsers.push({ date: d, value: running })
+  })
+
+  return {
+    dates,
+    daily,
+    loginsByWeekday,
+    errorTotals,
+    errorPagesTop,
+    profileDist,
+    retention,
+    funnel,
+    seg,
+    cumulativeUsers
+  }
+}

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -7,11 +7,29 @@ import AdminChartsUsersExplainPage from '../pages/adminChartsUsersExplainPage.js
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
+import AdminDashboardPage from '../pages/adminDashboardPage.jsx'
+import AdminGraphPage from '../pages/adminGraphPage.jsx'
+import AdminGraphGrowthPage from '../pages/adminGraphGrowthPage.jsx'
+import AdminGraphEngagementPage from '../pages/adminGraphEngagementPage.jsx'
+import AdminGraphReliabilityPage from '../pages/adminGraphReliabilityPage.jsx'
+import AdminGraphRevenuePage from '../pages/adminGraphRevenuePage.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
   { path: 'logout', element: <AdminLogoutPage />, label: 'Logout' },
   { index: true, element: <AdminPage />, label: 'Home' },
+  { path: 'dashboard', element: <AdminDashboardPage />, label: 'Dashboard' },
+  {
+    path: 'graph',
+    element: <AdminGraphPage />,
+    label: 'Graph',
+    children: [
+      { path: 'growth', element: <AdminGraphGrowthPage />, label: 'Growth' },
+      { path: 'engagement', element: <AdminGraphEngagementPage />, label: 'Engagement' },
+      { path: 'reliability', element: <AdminGraphReliabilityPage />, label: 'Reliability' },
+      { path: 'revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' }
+    ]
+  },
   {
     path: 'charts',
     element: <AdminChartsPage />,

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import { loadMetrics } from '../app/metrics.js'
+
+export default function AdminDashboardPage() {
+  const title = 'Admin Dashboard'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    loadMetrics().then(setData)
+  }, [])
+
+  if (!data) return <div>Loading...</div>
+
+  const { daily } = data
+  const labels = daily.map(d => d.date)
+
+  const dauData = { labels, datasets: [{ label: 'DAU', data: daily.map(d => d.dau), borderColor: '#36a2eb' }] }
+  const convData = { labels, datasets: [{ label: 'Conversion', data: daily.map(d => d.conversion_calc * 100), borderColor: '#ff6384' }] }
+  const errData = { labels, datasets: [{ label: 'Error Rate', data: daily.map(d => d.error_rate), borderColor: '#ff9f40' }] }
+  const subsData = { labels, datasets: [{ label: 'Subs', data: daily.map(d => d.subs), backgroundColor: '#4bc0c0' }] }
+
+  const commonLineOpts = { plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }
+  const commonBarOpts = { plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } }
+
+  const period = `${labels[0]} to ${labels[labels.length - 1]}`
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+        <Link to="/admin/graph/growth" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Line data={dauData} options={commonLineOpts} />
+          <p>Goal: growth | Source: events | Period: {period}</p>
+        </Link>
+        <Link to="/admin/graph/engagement" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Line data={convData} options={commonLineOpts} />
+          <p>Goal: conversion | Source: activity | Period: {period}</p>
+        </Link>
+        <Link to="/admin/graph/reliability" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Line data={errData} options={commonLineOpts} />
+          <p>Goal: stability | Source: activity | Period: {period}</p>
+        </Link>
+        <Link to="/admin/graph/revenue" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+          <Bar data={subsData} options={commonBarOpts} />
+          <p>Goal: revenue | Source: events | Period: {period}</p>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import { loadMetrics } from '../app/metrics.js'
+
+export default function AdminGraphEngagementPage() {
+  const title = 'Engagement Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => { document.title = fullTitle }, [fullTitle])
+  useEffect(() => { loadMetrics().then(setData) }, [])
+
+  if (!data) return <div>Loading...</div>
+  const { daily, retention, profileDist } = data
+  const labels = daily.map(d => d.date)
+
+  const sessionsConvData = {
+    labels,
+    datasets: [
+      { type: 'bar', label: 'sessions', data: daily.map(d => d.sessions), backgroundColor: '#36a2eb', yAxisID: 'y' },
+      { type: 'line', label: 'conversion%', data: daily.map(d => d.conversion_calc * 100), borderColor: '#ff6384', yAxisID: 'y1' },
+      { type: 'line', label: 'conversion', data: daily.map(d => d.conversion * 100), borderColor: '#4bc0c0', yAxisID: 'y1', borderDash: [5,5] }
+    ]
+  }
+
+  const stickinessData = {
+    labels,
+    datasets: [
+      { label: 'stickiness', data: daily.map(d => (d.mau ? d.dau / d.mau : 0)), borderColor: '#36a2eb' },
+      { label: '0.3', data: labels.map(() => 0.3), borderColor: '#ff0000', borderDash: [5,5], pointRadius: 0 },
+      { label: '0.5', data: labels.map(() => 0.5), borderColor: '#00aa00', borderDash: [5,5], pointRadius: 0 }
+    ]
+  }
+
+  function color(val) {
+    return `rgba(54,162,235,${val})`
+  }
+
+  const profileData = (() => {
+    const labels = ['Device', 'OS', 'Browser']
+    const datasets = []
+    const blocks = [profileDist.device, profileDist.os, profileDist.browser]
+    blocks.forEach((dist, idx) => {
+      const total = Object.values(dist).reduce((a,b) => a + b, 0)
+      Object.entries(dist).forEach(([k, v]) => {
+        const arr = [0,0,0]
+        arr[idx] = total ? (v / total) * 100 : 0
+        datasets.push({ label: k, data: arr, stack: 's' + idx })
+      })
+    })
+    return { labels, datasets }
+  })()
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <div style={{ maxWidth: '800px' }}>
+        <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
+        <p>Goal: load vs conversion | Source: activity | Formula: signups/visits Δ to conversion | Period: all dates</p>
+        <Line data={stickinessData} />
+        <p>Goal: product stickiness | Source: events | Formula: DAU/MAU | Period: all dates</p>
+        <table style={{ borderCollapse: 'collapse' }}>
+          <thead><tr><th>Week</th><th>d+7</th><th>d+14</th><th>d+28</th></tr></thead>
+          <tbody>
+            {retention.map(r => (
+              <tr key={r.cohort}>
+                <td>{r.cohort}</td>
+                <td style={{ background: color(r.d7) }}>{(r.d7 * 100).toFixed(0)}%</td>
+                <td style={{ background: color(r.d14) }}>{(r.d14 * 100).toFixed(0)}%</td>
+                <td style={{ background: color(r.d28) }}>{(r.d28 * 100).toFixed(0)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p>Goal: cohort retention | Source: users | Formula: activity at d+N | Period: all cohorts</p>
+        <Bar data={profileData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
+        <p>Goal: platform profile | Source: users | Period: last 30 days</p>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import { loadMetrics } from '../app/metrics.js'
+
+export default function AdminGraphGrowthPage() {
+  const title = 'Growth Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  useEffect(() => {
+    loadMetrics().then(setData)
+  }, [])
+
+  if (!data) return <div>Loading...</div>
+  const { daily, loginsByWeekday } = data
+  const labels = daily.map(d => d.date)
+
+  const areaData = {
+    labels,
+    datasets: [
+      {
+        label: 'DAU',
+        data: daily.map(d => d.dau),
+        type: 'line',
+        fill: true,
+        stack: 'aud',
+        backgroundColor: 'rgba(54,162,235,0.4)',
+        borderColor: 'rgba(54,162,235,1)'
+      },
+      {
+        label: 'WAU',
+        data: daily.map(d => d.wau),
+        type: 'line',
+        fill: true,
+        stack: 'aud',
+        backgroundColor: 'rgba(255,206,86,0.4)',
+        borderColor: 'rgba(255,206,86,1)'
+      },
+      {
+        label: 'MAU',
+        data: daily.map(d => d.mau),
+        type: 'line',
+        fill: true,
+        stack: 'aud',
+        backgroundColor: 'rgba(75,192,192,0.4)',
+        borderColor: 'rgba(75,192,192,1)'
+      },
+      {
+        label: 'SMA7',
+        data: daily.map(d => d.sma7),
+        type: 'line',
+        fill: false,
+        borderColor: '#000'
+      }
+    ]
+  }
+
+  const newReturningData = {
+    labels,
+    datasets: [
+      {
+        label: 'New',
+        data: daily.map(d => d.newUsers),
+        type: 'line',
+        fill: true,
+        stack: 'nr',
+        backgroundColor: 'rgba(153,102,255,0.4)',
+        borderColor: 'rgba(153,102,255,1)'
+      },
+      {
+        label: 'Returning',
+        data: daily.map(d => d.returningUsers),
+        type: 'line',
+        fill: true,
+        stack: 'nr',
+        backgroundColor: 'rgba(255,99,132,0.4)',
+        borderColor: 'rgba(255,99,132,1)'
+      }
+    ]
+  }
+
+  const funnelTopData = {
+    labels,
+    datasets: [
+      { label: 'visits', data: daily.map(d => d.visits), borderColor: '#36a2eb' },
+      { label: 'signups', data: daily.map(d => d.signups), borderColor: '#ff6384' },
+      { label: 'logins', data: daily.map(d => d.logins), borderColor: '#4bc0c0' }
+    ]
+  }
+
+  const weekdayData = {
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    datasets: [
+      { label: 'Logins', data: loginsByWeekday, backgroundColor: '#ffcd56' }
+    ]
+  }
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <div style={{ maxWidth: '800px' }}>
+        <Line data={areaData} options={{ stacked: true }} />
+        <p>Goal: compare active audiences | Source: events | Formula: DAU/WAU/MAU/SMA7 | Period: all dates</p>
+        <Line data={newReturningData} options={{ stacked: true }} />
+        <p>Goal: share of new vs returning | Source: events | Formula: rule "new" | Period: all dates</p>
+        <Line data={funnelTopData} />
+        <p>Goal: upper funnel dynamics | Source: activity | Period: all dates</p>
+        <Bar data={weekdayData} />
+        <p>Goal: seasonality | Source: events | Formula: aggregate by weekday | Period: all dates</p>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphPage.jsx
+++ b/src/admin/pages/adminGraphPage.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { Outlet, useOutlet } from 'react-router-dom'
+import AuthMessage from '../app/authMessage.jsx'
+
+export default function AdminGraphPage() {
+  const title = 'Admin Graph Page'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const outlet = useOutlet()
+  useEffect(() => { document.title = fullTitle }, [fullTitle])
+  if (outlet) return outlet
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <AuthMessage />
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import { loadMetrics } from '../app/metrics.js'
+
+export default function AdminGraphReliabilityPage() {
+  const title = 'Reliability Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => { document.title = fullTitle }, [fullTitle])
+  useEffect(() => { loadMetrics().then(setData) }, [])
+
+  if (!data) return <div>Loading...</div>
+  const { daily, errorTotals, errorPagesTop } = data
+  const labels = daily.map(d => d.date)
+
+  const errRateData = {
+    labels,
+    datasets: [
+      { label: 'error_rate', data: daily.map(d => d.error_rate), borderColor: '#ff6384' },
+      { label: 'SLO 0.03', data: labels.map(() => 0.03), borderColor: '#00aa00', borderDash: [5,5], pointRadius: 0 }
+    ]
+  }
+
+  const codes = Object.keys(errorTotals)
+  const stackedErrorsData = {
+    labels,
+    datasets: codes.map(c => ({
+      label: c,
+      data: daily.map(d => d.errorsByCode[c] || 0),
+      type: 'line',
+      fill: true,
+      stack: 'codes'
+    }))
+  }
+
+  const totalsSorted = Object.entries(errorTotals).sort((a,b) => b[1] - a[1])
+  const labelsPareto = totalsSorted.map(([c]) => c)
+  const barVals = totalsSorted.map(([,v]) => v)
+  const totalSum = barVals.reduce((a,b)=>a+b,0)
+  const cum = []
+  let run = 0
+  barVals.forEach(v => { run += v; cum.push(run / totalSum * 100) })
+  const paretoData = {
+    labels: labelsPareto,
+    datasets: [
+      { type: 'bar', label: 'errors', data: barVals, backgroundColor: '#36a2eb', yAxisID: 'y' },
+      { type: 'line', label: 'cumulative %', data: cum, borderColor: '#ff6384', yAxisID: 'y1' }
+    ]
+  }
+
+  const pagesData = {
+    labels: errorPagesTop.map(([p]) => p),
+    datasets: [ { label: 'errors', data: errorPagesTop.map(([,v]) => v), backgroundColor: '#ffcd56' } ]
+  }
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <div style={{ maxWidth: '800px' }}>
+        <Line data={errRateData} />
+        <p>Goal: stability per session | Source: activity | Formula: errors/sessions | Period: all dates</p>
+        <Line data={stackedErrorsData} options={{ stacked: true }} />
+        <p>Goal: incident structure | Source: activity | Formula: errors by code | Period: all dates</p>
+        <Bar data={paretoData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
+        <p>Goal: 80/20 principle | Source: activity | Period: all dates</p>
+        <Bar data={pagesData} options={{ indexAxis: 'y' }} />
+        <p>Goal: problematic pages | Source: events | Formula: type=error aggregated | Period: all dates</p>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import { Line, Bar } from 'react-chartjs-2'
+import '../app/chartSetup.js'
+import { loadMetrics } from '../app/metrics.js'
+
+export default function AdminGraphRevenuePage() {
+  const title = 'Revenue Metrics'
+  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const [data, setData] = useState(null)
+
+  useEffect(() => { document.title = fullTitle }, [fullTitle])
+  useEffect(() => { loadMetrics().then(setData) }, [])
+
+  if (!data) return <div>Loading...</div>
+  const { daily, funnel, seg, cumulativeUsers } = data
+  const labels = daily.map(d => d.date)
+
+  const funnelLabels = ['visit','signup','verify','login','first_action','subscribe']
+  const funnelData = {
+    labels: funnelLabels,
+    datasets: [ { label: 'count', data: funnelLabels.map(s => funnel[s]), backgroundColor: '#36a2eb' } ]
+  }
+
+  const segData = (() => {
+    const labels = ['plan','utmSource','country']
+    const datasets = []
+    const blocks = [seg.plan, seg.utmSource, seg.country]
+    blocks.forEach((dist, idx) => {
+      const total = Object.values(dist).reduce((a,b)=>a+b,0)
+      Object.entries(dist).forEach(([k,v]) => {
+        const arr = [0,0,0]
+        arr[idx] = total ? (v/total)*100 : 0
+        datasets.push({ label: k, data: arr, stack: 's'+idx })
+      })
+    })
+    return { labels, datasets }
+  })()
+
+  const signupSubData = {
+    labels,
+    datasets: [
+      { type: 'bar', label: 'signups', data: daily.map(d => d.signups), backgroundColor: '#36a2eb', yAxisID: 'y' },
+      { type: 'line', label: 'subscribe', data: daily.map(d => d.subs), borderColor: '#ff6384', yAxisID: 'y1' }
+    ]
+  }
+
+  const cumulativeData = {
+    labels: cumulativeUsers.map(d => d.date),
+    datasets: [ { label: 'users', data: cumulativeUsers.map(d => d.value), borderColor: '#4bc0c0' } ]
+  }
+
+  return (
+    <div>
+      <h1>{fullTitle}</h1>
+      <div style={{ maxWidth: '800px' }}>
+        <Bar data={funnelData} />
+        <p>Goal: step drop-off | Source: events | Formula: funnel totals | Period: all dates</p>
+        <Bar data={segData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
+        <p>Goal: paying segments | Source: events+users | Period: all subs</p>
+        <Bar data={signupSubData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right' } } }} />
+        <p>Goal: inflow vs paid conversions | Source: activity+events | Period: all dates</p>
+        <Line data={cumulativeData} />
+        <p>Goal: user base growth | Source: users | Period: all dates</p>
+      </div>
+    </div>
+  )
+}

--- a/src/urlTree.json
+++ b/src/urlTree.json
@@ -7,6 +7,17 @@
     "children": [
       { "path": "/admin/login", "name": "Login", "children": [] },
       { "path": "/admin/logout", "name": "Logout", "children": [] },
+      { "path": "/admin/dashboard", "name": "Dashboard", "children": [] },
+      {
+        "path": "/admin/graph",
+        "name": "Graph",
+        "children": [
+          { "path": "/admin/graph/growth", "name": "Growth", "children": [] },
+          { "path": "/admin/graph/engagement", "name": "Engagement", "children": [] },
+          { "path": "/admin/graph/reliability", "name": "Reliability", "children": [] },
+          { "path": "/admin/graph/revenue", "name": "Revenue", "children": [] }
+        ]
+      },
       {
         "path": "/admin/charts",
         "name": "Charts",


### PR DESCRIPTION
## Summary
- add admin dashboard with mini charts
- implement growth, engagement, reliability, and revenue graph pages
- compute metrics from mock activity, event, and user data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2931fbac0832e87fe462cfe34fec5