### PR TITLE
fix: ensure admin graphs reload mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.52
+Current version: 0.0.53
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.51",
+  "version": "0.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.51",
+      "version": "0.0.53",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.52",
+  "version": "0.0.53",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1349,6 +1349,28 @@
           "scope": "analytics"
         }
       ]
+    },
+    {
+      "version": "0.0.53",
+      "date": "2025-08-29",
+      "time": "17:01:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Bypassed cache when loading admin metrics to update mock data",
+          "weight": 40,
+          "type": "fix",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Обеспечен обход кэша при загрузке метрик админки для обновления мок-данных",
+          "weight": 40,
+          "type": "fix",
+          "scope": "analytics"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2588,6 +2610,28 @@
           "description": "Добавлены админский дашборд и аналитические графики",
           "weight": 70,
           "type": "feat",
+          "scope": "analytics"
+        }
+      ]
+    },
+    {
+      "version": "0.0.53",
+      "date": "2025-08-29",
+      "time": "17:01:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Bypassed cache when loading admin metrics to update mock data",
+          "weight": 40,
+          "type": "fix",
+          "scope": "analytics"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Обеспечен обход кэша при загрузке метрик админки для обновления мок-данных",
+          "weight": 40,
+          "type": "fix",
           "scope": "analytics"
         }
       ]

--- a/src/admin/app/metrics.js
+++ b/src/admin/app/metrics.js
@@ -15,10 +15,11 @@ function dateRange(start, end) {
 }
 
 export async function loadMetrics() {
+  const opts = { cache: 'no-store' }
   const [events, activity, users] = await Promise.all([
-    fetch('/mocks/events.json').then(r => r.json()),
-    fetch('/mocks/activity.json').then(r => r.json()),
-    fetch('/mocks/users.json').then(r => r.json())
+    fetch('/mocks/events.json', opts).then(r => r.json()),
+    fetch('/mocks/activity.json', opts).then(r => r.json()),
+    fetch('/mocks/users.json', opts).then(r => r.json())
   ])
 
   const eventDates = events.map(e => e.ts.slice(0, 10))

--- a/src/admin/pages/adminChartsUsersChartjs2Page.jsx
+++ b/src/admin/pages/adminChartsUsersChartjs2Page.jsx
@@ -19,7 +19,9 @@ export default function AdminChartsUsersChartjs2Page() {
   }, [fullTitle])
 
   useEffect(() => {
-    fetch('/mocks/users.json').then(r => r.json()).then(setUsers)
+    fetch('/mocks/users.json', { cache: 'no-store' })
+      .then(r => r.json())
+      .then(setUsers)
   }, [])
 
   function aggregate(arr, key) {

--- a/src/admin/pages/adminChartsUsersExplainPage.jsx
+++ b/src/admin/pages/adminChartsUsersExplainPage.jsx
@@ -75,7 +75,7 @@ export default function AdminChartsUsersExplainPage() {
 
   useEffect(() => {
     document.title = fullTitle
-    fetch('/mocks/users.json')
+    fetch('/mocks/users.json', { cache: 'no-store' })
       .then(r => r.json())
       .then(data => {
         setExample(data[0])

--- a/src/admin/pages/adminChartsUsersRechartsPage.jsx
+++ b/src/admin/pages/adminChartsUsersRechartsPage.jsx
@@ -24,7 +24,9 @@ export default function AdminChartsUsersRechartsPage() {
   }, [fullTitle])
 
   useEffect(() => {
-    fetch('/mocks/users.json').then(r => r.json()).then(setUsers)
+    fetch('/mocks/users.json', { cache: 'no-store' })
+      .then(r => r.json())
+      .then(setUsers)
   }, [])
 
   function aggregate(arr, key) {


### PR DESCRIPTION
## Summary
- bypass browser cache when fetching mock metrics so admin dashboards reflect file edits
- document fix in release notes and bump version to 0.0.53

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b299515f40832ebf0fe944592e7316