### PR TITLE
fix: redirect authenticated admin from login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # ACP+Charts now
-Current version: 0.0.54
+Current version: 0.0.55
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
 - Admin login at `/admin/login` using env credentials
+- Authenticated admins visiting `/admin/login` are redirected back to the previous page
 - Admin access to charts dashboard, analytics graphs, and UI demos of 30 forms and 30 hashtags
 - Logout at `/admin/logout` with redirect for unauthenticated routes
 - Return to originally requested admin page after login
@@ -36,6 +37,7 @@ _Only this section of the readme can be maintained using Russian language_
   - [x] 2.5 Добавить страницу /admin/logout, сообщение об успешной авторизации и ссылку на выход.
   - [x] 2.6 Возвращать на запрошенную страницу /admin/* после успешной авторизации.
   - [x] 2.7 Обновить сообщение об успешной авторизации на "User admin is authenticated. You can log out."
+  - [x] 2.8 Перенаправлять авторизованного админа со страницы /admin/login на предыдущую страницу
 
 3. Графики
   - [x] 3.1 Создать страницы /admin/charts/users и /admin/charts/users/recharts с 20 вариантами графиков на Recharts. После каждого графика добавить описание и пример кода в textarea. Данные автоматически берутся из public/mocks/users.json.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.54",
+  "version": "0.0.55",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1393,6 +1393,28 @@
           "scope": "admin-navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.55",
+      "date": "2025-08-29",
+      "time": "17:03:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Redirected authenticated admin from login page to previous page",
+          "weight": 30,
+          "type": "fix",
+          "scope": "auth"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Авторизованный админ перенаправляется со страницы входа на предыдущую страницу",
+          "weight": 30,
+          "type": "fix",
+          "scope": "auth"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2677,6 +2699,28 @@
           "weight": 60,
           "type": "refactor",
           "scope": "admin-navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.55",
+      "date": "2025-08-29",
+      "time": "17:03:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Redirected authenticated admin from login page to previous page",
+          "weight": 30,
+          "type": "fix",
+          "scope": "auth"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Авторизованный админ перенаправляется со страницы входа на предыдущую страницу",
+          "weight": 30,
+          "type": "fix",
+          "scope": "auth"
         }
       ]
     }

--- a/src/admin/pages/adminLoginPage.jsx
+++ b/src/admin/pages/adminLoginPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { isAdminAuth } from '../app/auth.js'
 import AuthMessage from '../app/authMessage.jsx'
 import './adminUiPage.css'
 
@@ -13,6 +14,16 @@ export default function AdminLoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const navigate = useNavigate()
+
+  useEffect(() => {
+    if (isAdminAuth()) {
+      if (window.history.length > 1) {
+        navigate(-1)
+      } else {
+        navigate('/admin', { replace: true })
+      }
+    }
+  }, [navigate])
 
   const handleSubmit = e => {
     e.preventDefault()


### PR DESCRIPTION
## Summary
- redirect already-authenticated admins away from /admin/login to their previous page
- document new login redirect behavior and bump version to 0.0.55

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ad61c1e8832e86cb6770066f7320