### PR TITLE
feat(admin-sidebar): show project name and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.55
+Current version: 0.0.56
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -14,6 +14,7 @@ Current version: 0.0.55
 - Admin pages display "Subpages:" with a full URL tree when subpages exist
 - Navigation sidebars derive from the same tree; admin lists all URLs flat (no nested lists), public lists non-admin URLs
 - User and admin sidebars highlight the active link
+- Admin sidebar shows project name and current version above the URL/Name toggle
 - Charts dashboard at `/admin/charts` with mini charts for growth, engagement, reliability, and revenue
 - Detailed analytics pages at `/admin/charts/*` for growth, engagement, reliability, and revenue
 - Chart.js users charts at `/admin/ui/charts`
@@ -115,6 +116,7 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+ - [x] 17.3 Показать название и версию проекта над переключателем URL/Name
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.53",
+  "version": "0.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.53",
+      "version": "0.0.56",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.55",
+  "version": "0.0.56",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1415,6 +1415,28 @@
           "scope": "auth"
         }
       ]
+    },
+    {
+      "version": "0.0.56",
+      "date": "2025-08-29",
+      "time": "17:05:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Displayed project name and version in admin sidebar",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Отображено название и версия проекта в сайдбаре админа",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2721,6 +2743,28 @@
           "weight": 30,
           "type": "fix",
           "scope": "auth"
+        }
+      ]
+    },
+    {
+      "version": "0.0.56",
+      "date": "2025-08-29",
+      "time": "17:05:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Displayed project name and version in admin sidebar",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Отображено название и версия проекта в сайдбаре админа",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
         }
       ]
     }

--- a/src/admin/app/barLeftAdmin.css
+++ b/src/admin/app/barLeftAdmin.css
@@ -75,6 +75,11 @@
   font-size: 0.9em;
 }
 
+.sidebar-footer .project-info {
+  text-align: right;
+  margin-bottom: 4px;
+}
+
 .sidebar-footer label {
   display: flex;
   align-items: center;

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { Sidebar, Home, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
 import urlTree from '../../urlTree.json'
+import { projectName, projectVersion } from '../../projectInfo'
 import './barLeftAdmin.css'
 
 const flattenTree = nodes =>
@@ -110,6 +111,9 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
             </ul>
           </nav>
           <div className="sidebar-footer">
+            <div className="project-info">
+              {projectName} {projectVersion}
+            </div>
             <label>
               <input type="checkbox" checked={showNames} onChange={toggleNames} />
               {showNames ? 'Name' : 'URL'}

--- a/src/projectInfo.js
+++ b/src/projectInfo.js
@@ -1,0 +1,4 @@
+import pkg from '../package.json'
+
+export const projectName = 'ACPC'
+export const projectVersion = pkg.version


### PR DESCRIPTION
## Summary
- display project name and current version above the URL/Name switch in the admin sidebar
- centralize project metadata and document the sidebar update
- record release notes for version 0.0.56

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b3075d7c832eae388a8676004afc