### PR TITLE
feat(admin-sidebar): show project info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.55
+Current version: 0.0.56
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -115,6 +115,7 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+ - [x] 17.3 Добавить название проекта и версию над переключателем URL/Name в админском сайдбаре
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.53",
+  "version": "0.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.53",
+      "version": "0.0.56",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.55",
+  "version": "0.0.56",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1415,6 +1415,28 @@
           "scope": "auth"
         }
       ]
+    },
+    {
+      "version": "0.0.56",
+      "date": "2025-08-29",
+      "time": "17:04:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added project name and version to admin sidebar",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено название проекта и версия в сайдбар админа",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2721,6 +2743,28 @@
           "weight": 30,
           "type": "fix",
           "scope": "auth"
+        }
+      ]
+    },
+    {
+      "version": "0.0.56",
+      "date": "2025-08-29",
+      "time": "17:04:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added project name and version to admin sidebar",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено название проекта и версия в сайдбар админа",
+          "weight": 30,
+          "type": "feat",
+          "scope": "admin-sidebar"
         }
       ]
     }

--- a/src/admin/app/barLeftAdmin.css
+++ b/src/admin/app/barLeftAdmin.css
@@ -81,3 +81,8 @@
   gap: 4px;
   cursor: pointer;
 }
+
+.sidebar-footer .project-info {
+  text-align: right;
+  margin-bottom: 4px;
+}

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -3,6 +3,7 @@ import { Link, NavLink } from 'react-router-dom'
 import { Sidebar, Home, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
 import urlTree from '../../urlTree.json'
 import './barLeftAdmin.css'
+import { projectName, projectVersion } from '../../projectInfo'
 
 const flattenTree = nodes =>
   nodes.flatMap(n => [{ path: n.path, name: n.name }, ...flattenTree(n.children)])
@@ -110,6 +111,9 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
             </ul>
           </nav>
           <div className="sidebar-footer">
+            <div className="project-info">
+              {projectName} {projectVersion}
+            </div>
             <label>
               <input type="checkbox" checked={showNames} onChange={toggleNames} />
               {showNames ? 'Name' : 'URL'}

--- a/src/projectInfo.js
+++ b/src/projectInfo.js
@@ -1,0 +1,4 @@
+import pkg from '../package.json'
+
+export const projectName = pkg.name.toUpperCase()
+export const projectVersion = pkg.version


### PR DESCRIPTION
## Summary
- show project name and version above URL/Name toggle in admin sidebar
- centralize project metadata in `projectInfo.js`
- document new sidebar feature in README and release notes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b58e6534832ea504c2cce84661c7