### PR TITLE
style: move inline styles to CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.56
+Current version: 0.0.57
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -115,6 +115,9 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+
+18. Семантическая разметка
+ - [x] 18.1 Добавить классы контейнерам и вынести стили в CSS
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/index.html
+++ b/index.html
@@ -5,22 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <style>
-      html {
-        background-color: #ffffff;
-        color: #213547;
-      }
-      @media (prefers-color-scheme: dark) {
-        html {
-          background-color: #242424;
-          color: rgba(255, 255, 255, 0.87);
-        }
-      }
-    </style>
     <title>ACPC</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body class="site-body">
+    <div id="root" class="app-root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.53",
+  "version": "0.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.53",
+      "version": "0.0.57",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.56",
+  "version": "0.0.57",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1437,6 +1437,28 @@
           "scope": "analytics"
         }
       ]
+    },
+    {
+      "version": "0.0.57",
+      "date": "2025-08-29",
+      "time": "17:05:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Moved inline styles into CSS files and added semantic classes to containers",
+          "weight": 30,
+          "type": "style",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Перенесены встроенные стили в CSS и добавлены семантические классы контейнерам",
+          "weight": 30,
+          "type": "style",
+          "scope": "layout"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2765,6 +2787,28 @@
           "weight": 40,
           "type": "fix",
           "scope": "analytics"
+        }
+      ]
+    },
+    {
+      "version": "0.0.57",
+      "date": "2025-08-29",
+      "time": "17:05:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Moved inline styles into CSS files and added semantic classes to containers",
+          "weight": 30,
+          "type": "style",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Перенесены встроенные стили в CSS и добавлены семантические классы контейнерам",
+          "weight": 30,
+          "type": "style",
+          "scope": "layout"
         }
       ]
     }

--- a/src/admin/app/subPages.css
+++ b/src/admin/app/subPages.css
@@ -1,0 +1,3 @@
+.subpages {
+  margin-top: 2rem;
+}

--- a/src/admin/app/subPages.jsx
+++ b/src/admin/app/subPages.jsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from 'react-router-dom'
 import urlTree from '../../urlTree.json'
+import './subPages.css'
 
 function findNode(path, nodes) {
   for (const node of nodes) {
@@ -29,7 +30,7 @@ export default function SubPages() {
   const children = node ? node.children : []
   if (children.length === 0) return null
   return (
-    <div style={{ marginTop: '2rem' }}>
+    <div className="subpages">
       <h2>Subpages:</h2>
       {renderTree(children)}
     </div>

--- a/src/admin/pages/adminDashboardPage.css
+++ b/src/admin/pages/adminDashboardPage.css
@@ -1,0 +1,13 @@
+.dashboard-page {
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.dashboard-card {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -3,6 +3,7 @@ import { Link, useOutlet } from 'react-router-dom'
 import { Line, Bar } from 'react-chartjs-2'
 import '../app/chartSetup.js'
 import { loadMetrics } from '../app/metrics.js'
+import './adminDashboardPage.css'
 
 export default function AdminDashboardPage() {
   const title = 'Charts Dashboard'
@@ -19,7 +20,7 @@ export default function AdminDashboardPage() {
   }, [outlet])
 
   if (outlet) return outlet
-  if (!data) return <div>Loading...</div>
+  if (!data) return <div className="loading">Loading...</div>
 
   const { daily } = data
   const labels = daily.map(d => d.date)
@@ -35,26 +36,26 @@ export default function AdminDashboardPage() {
   const period = `${labels[0]} to ${labels[labels.length - 1]}`
 
   return (
-    <div>
+    <main className="dashboard-page">
       <h1>{fullTitle}</h1>
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-        <Link to="/admin/charts/growth" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+      <section className="dashboard-grid">
+        <Link to="/admin/charts/growth" className="dashboard-card">
           <Line data={dauData} options={commonLineOpts} />
           <p>Goal: growth | Source: events | Period: {period}</p>
         </Link>
-        <Link to="/admin/charts/engagement" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+        <Link to="/admin/charts/engagement" className="dashboard-card">
           <Line data={convData} options={commonLineOpts} />
           <p>Goal: conversion | Source: activity | Period: {period}</p>
         </Link>
-        <Link to="/admin/charts/reliability" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+        <Link to="/admin/charts/reliability" className="dashboard-card">
           <Line data={errData} options={commonLineOpts} />
           <p>Goal: stability | Source: activity | Period: {period}</p>
         </Link>
-        <Link to="/admin/charts/revenue" style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+        <Link to="/admin/charts/revenue" className="dashboard-card">
           <Bar data={subsData} options={commonBarOpts} />
           <p>Goal: revenue | Source: events | Period: {period}</p>
         </Link>
-      </div>
-    </div>
+      </section>
+    </main>
   )
 }

--- a/src/admin/pages/adminGraphEngagementPage.css
+++ b/src/admin/pages/adminGraphEngagementPage.css
@@ -1,0 +1,10 @@
+.engagement-page {
+}
+
+.engagement-page__content {
+  max-width: 800px;
+}
+
+.engagement-page__table {
+  border-collapse: collapse;
+}

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Line, Bar } from 'react-chartjs-2'
 import '../app/chartSetup.js'
 import { loadMetrics } from '../app/metrics.js'
+import './adminGraphEngagementPage.css'
 
 export default function AdminGraphEngagementPage() {
   const title = 'Engagement Metrics'
@@ -11,7 +12,7 @@ export default function AdminGraphEngagementPage() {
   useEffect(() => { document.title = fullTitle }, [fullTitle])
   useEffect(() => { loadMetrics().then(setData) }, [])
 
-  if (!data) return <div>Loading...</div>
+  if (!data) return <div className="loading">Loading...</div>
   const { daily, retention, profileDist } = data
   const labels = daily.map(d => d.date)
 
@@ -53,14 +54,14 @@ export default function AdminGraphEngagementPage() {
   })()
 
   return (
-    <div>
+    <main className="engagement-page">
       <h1>{fullTitle}</h1>
-      <div style={{ maxWidth: '800px' }}>
+      <section className="engagement-page__content">
         <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
         <p>Goal: load vs conversion | Source: activity | Formula: signups/visits Δ to conversion | Period: all dates</p>
         <Line data={stickinessData} />
         <p>Goal: product stickiness | Source: events | Formula: DAU/MAU | Period: all dates</p>
-        <table style={{ borderCollapse: 'collapse' }}>
+        <table className="engagement-page__table">
           <thead><tr><th>Week</th><th>d+7</th><th>d+14</th><th>d+28</th></tr></thead>
           <tbody>
             {retention.map(r => (
@@ -76,7 +77,7 @@ export default function AdminGraphEngagementPage() {
         <p>Goal: cohort retention | Source: users | Formula: activity at d+N | Period: all cohorts</p>
         <Bar data={profileData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
         <p>Goal: platform profile | Source: users | Period: last 30 days</p>
-      </div>
-    </div>
+      </section>
+    </main>
   )
 }

--- a/src/admin/pages/adminGraphGrowthPage.css
+++ b/src/admin/pages/adminGraphGrowthPage.css
@@ -1,0 +1,6 @@
+.growth-page {
+}
+
+.growth-page__content {
+  max-width: 800px;
+}

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Line, Bar } from 'react-chartjs-2'
 import '../app/chartSetup.js'
 import { loadMetrics } from '../app/metrics.js'
+import './adminGraphGrowthPage.css'
 
 export default function AdminGraphGrowthPage() {
   const title = 'Growth Metrics'
@@ -16,7 +17,7 @@ export default function AdminGraphGrowthPage() {
     loadMetrics().then(setData)
   }, [])
 
-  if (!data) return <div>Loading...</div>
+  if (!data) return <div className="loading">Loading...</div>
   const { daily, loginsByWeekday } = data
   const labels = daily.map(d => d.date)
 
@@ -101,9 +102,9 @@ export default function AdminGraphGrowthPage() {
   }
 
   return (
-    <div>
+    <main className="growth-page">
       <h1>{fullTitle}</h1>
-      <div style={{ maxWidth: '800px' }}>
+      <section className="growth-page__content">
         <Line data={areaData} options={{ stacked: true }} />
         <p>Goal: compare active audiences | Source: events | Formula: DAU/WAU/MAU/SMA7 | Period: all dates</p>
         <Line data={newReturningData} options={{ stacked: true }} />
@@ -112,7 +113,7 @@ export default function AdminGraphGrowthPage() {
         <p>Goal: upper funnel dynamics | Source: activity | Period: all dates</p>
         <Bar data={weekdayData} />
         <p>Goal: seasonality | Source: events | Formula: aggregate by weekday | Period: all dates</p>
-      </div>
-    </div>
+      </section>
+    </main>
   )
 }

--- a/src/admin/pages/adminGraphReliabilityPage.css
+++ b/src/admin/pages/adminGraphReliabilityPage.css
@@ -1,0 +1,6 @@
+.reliability-page {
+}
+
+.reliability-page__content {
+  max-width: 800px;
+}

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Line, Bar } from 'react-chartjs-2'
 import '../app/chartSetup.js'
 import { loadMetrics } from '../app/metrics.js'
+import './adminGraphReliabilityPage.css'
 
 export default function AdminGraphReliabilityPage() {
   const title = 'Reliability Metrics'
@@ -11,7 +12,7 @@ export default function AdminGraphReliabilityPage() {
   useEffect(() => { document.title = fullTitle }, [fullTitle])
   useEffect(() => { loadMetrics().then(setData) }, [])
 
-  if (!data) return <div>Loading...</div>
+  if (!data) return <div className="loading">Loading...</div>
   const { daily, errorTotals, errorPagesTop } = data
   const labels = daily.map(d => d.date)
 
@@ -56,9 +57,9 @@ export default function AdminGraphReliabilityPage() {
   }
 
   return (
-    <div>
+  <main className="reliability-page">
       <h1>{fullTitle}</h1>
-      <div style={{ maxWidth: '800px' }}>
+      <section className="reliability-page__content">
         <Line data={errRateData} />
         <p>Goal: stability per session | Source: activity | Formula: errors/sessions | Period: all dates</p>
         <Line data={stackedErrorsData} options={{ stacked: true }} />
@@ -67,7 +68,7 @@ export default function AdminGraphReliabilityPage() {
         <p>Goal: 80/20 principle | Source: activity | Period: all dates</p>
         <Bar data={pagesData} options={{ indexAxis: 'y' }} />
         <p>Goal: problematic pages | Source: events | Formula: type=error aggregated | Period: all dates</p>
-      </div>
-    </div>
+      </section>
+    </main>
   )
 }

--- a/src/admin/pages/adminGraphRevenuePage.css
+++ b/src/admin/pages/adminGraphRevenuePage.css
@@ -1,0 +1,6 @@
+.revenue-page {
+}
+
+.revenue-page__content {
+  max-width: 800px;
+}

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Line, Bar } from 'react-chartjs-2'
 import '../app/chartSetup.js'
 import { loadMetrics } from '../app/metrics.js'
+import './adminGraphRevenuePage.css'
 
 export default function AdminGraphRevenuePage() {
   const title = 'Revenue Metrics'
@@ -11,7 +12,7 @@ export default function AdminGraphRevenuePage() {
   useEffect(() => { document.title = fullTitle }, [fullTitle])
   useEffect(() => { loadMetrics().then(setData) }, [])
 
-  if (!data) return <div>Loading...</div>
+  if (!data) return <div className="loading">Loading...</div>
   const { daily, funnel, seg, cumulativeUsers } = data
   const labels = daily.map(d => d.date)
 
@@ -50,9 +51,9 @@ export default function AdminGraphRevenuePage() {
   }
 
   return (
-    <div>
+    <main className="revenue-page">
       <h1>{fullTitle}</h1>
-      <div style={{ maxWidth: '800px' }}>
+      <section className="revenue-page__content">
         <Bar data={funnelData} />
         <p>Goal: step drop-off | Source: events | Formula: funnel totals | Period: all dates</p>
         <Bar data={segData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
@@ -61,7 +62,7 @@ export default function AdminGraphRevenuePage() {
         <p>Goal: inflow vs paid conversions | Source: activity+events | Period: all dates</p>
         <Line data={cumulativeData} />
         <p>Goal: user base growth | Source: users | Period: all dates</p>
-      </div>
-    </div>
+      </section>
+    </main>
   )
 }

--- a/src/admin/pages/adminLoginPage.jsx
+++ b/src/admin/pages/adminLoginPage.jsx
@@ -45,7 +45,7 @@ export default function AdminLoginPage() {
 
   return (
     <div className="login-page">
-      <div>
+      <div className="login-page__content">
         <h1>Admin Login</h1>
         <AuthMessage />
         <form className="login-form variant-30" onSubmit={handleSubmit}>
@@ -69,7 +69,7 @@ export default function AdminLoginPage() {
           />
           <button type="submit" disabled={disabled}>Login</button>
         </form>
-        {error && <p style={{ color: 'red' }}>{error}</p>}
+        {error && <p className="login-error">{error}</p>}
       </div>
     </div>
   )

--- a/src/admin/pages/adminUiChartsPage.css
+++ b/src/admin/pages/adminUiChartsPage.css
@@ -1,0 +1,17 @@
+.admin-ui-charts-page {
+}
+
+.chart-example {
+  margin-bottom: 3rem;
+}
+
+.chart-example__chart {
+  width: 100%;
+  height: 300px;
+}
+
+.chart-example__code {
+  width: 100%;
+  height: 200px;
+  margin-top: 1rem;
+}

--- a/src/admin/pages/adminUiChartsPage.jsx
+++ b/src/admin/pages/adminUiChartsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from 'react'
 import AuthMessage from '../app/authMessage.jsx'
+import './adminUiChartsPage.css'
 import { Chart as ChartJS, registerables } from 'chart.js'
 import zoomPlugin from 'chartjs-plugin-zoom'
 import { TreemapController, TreemapElement } from 'chartjs-chart-treemap'
@@ -540,23 +541,23 @@ export default function AdminUiChartsPage() {
 
   function ChartExample({ title, description, code, children }) {
     return (
-      <section style={{ marginBottom: '3rem' }}>
+      <section className="chart-example">
         <h3>{title}</h3>
         <p>{description}</p>
-        <div style={{ width: '100%', height: 300 }}>
+        <div className="chart-example__chart">
           {children}
         </div>
         <textarea
           readOnly
           value={code}
-          style={{ width: '100%', height: '200px', marginTop: '1rem' }}
+          className="chart-example__code"
         />
       </section>
     )
   }
 
   return (
-    <div>
+    <main className="admin-ui-charts-page">
       <h1>{fullTitle}</h1>
       <AuthMessage />
       {chartExamples.map(({ title, description, render, code }) => (
@@ -564,7 +565,7 @@ export default function AdminUiChartsPage() {
           {render()}
         </ChartExample>
       ))}
-    </div>
+    </main>
   )
 }
 

--- a/src/admin/pages/adminUiPage.css
+++ b/src/admin/pages/adminUiPage.css
@@ -12,6 +12,13 @@
   height: calc(100vh - 32px);
 }
 
+.login-page__content {
+}
+
+.login-error {
+  color: red;
+}
+
 .login-form input,
 .login-form button {
   padding: 4px 8px;

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,12 @@
   }
 }
 
-body {
+html {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.site-body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
@@ -42,22 +47,25 @@ body {
   scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
 }
 
-#root {
+.app-root {
   display: flex;
   min-height: 100vh;
   width: 100%;
 }
 
-body::-webkit-scrollbar {
+.site-body::-webkit-scrollbar {
   width: 8px;
 }
 
-body::-webkit-scrollbar-thumb {
+.site-body::-webkit-scrollbar-thumb {
   background-color: var(--color-scrollbar-thumb);
 }
 
-body::-webkit-scrollbar-track {
+.site-body::-webkit-scrollbar-track {
   background-color: var(--color-scrollbar-track);
+}
+
+.loading {
 }
 
 a {

--- a/src/user/pages/mainPage.css
+++ b/src/user/pages/mainPage.css
@@ -1,0 +1,5 @@
+.main-page__icon {
+  height: 1em;
+  vertical-align: middle;
+  margin-right: 0.2em;
+}

--- a/src/user/pages/mainPage.jsx
+++ b/src/user/pages/mainPage.jsx
@@ -1,24 +1,21 @@
 import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import './mainPage.css'
 
 export default function MainPage() {
   useEffect(() => {
     document.title = 'ACPC'
   }, [])
   return (
-    <>
+    <main className="main-page">
       <h1>
-        <img
-          src="/icon.svg"
-          alt="ACPC icon"
-          style={{ height: '1em', verticalAlign: 'middle', marginRight: '0.2em' }}
-        />
+        <img src="/icon.svg" alt="ACPC icon" className="main-page__icon" />
         ACPC
       </h1>
       <p>Welcome to site with AdminCP with Charts!</p>
       <p>
         Go to <Link to="/admin">/admin</Link> to see.
       </p>
-    </>
+    </main>
   )
 }


### PR DESCRIPTION
## Summary
- replace inline styling with semantic class names across pages
- move root and page-specific styles into dedicated CSS files
- document class usage and bump version to 0.0.57

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b38f0e1c9c832eb372570eb8a14dc5