### PR TITLE
refactor: simplify release notes tag markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.57
+Current version: 0.0.58
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.57",
+  "version": "0.0.58",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1459,6 +1459,28 @@
           "scope": "layout"
         }
       ]
+    },
+    {
+      "version": "0.0.58",
+      "date": "2025-08-31",
+      "time": "06:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Simplified release notes tags by replacing nested divs with spans",
+          "weight": 20,
+          "type": "refactor",
+          "scope": "release-notes"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Упрощены теги заметок релизов, заменены вложенные div на span",
+          "weight": 20,
+          "type": "refactor",
+          "scope": "release-notes"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2790,27 +2812,49 @@
         }
       ]
     },
-    {
-      "version": "0.0.57",
-      "date": "2025-08-29",
-      "time": "17:05:00",
-      "timezone": "Asia/Bishkek",
-      "changes": [
-        {
-          "description": "Moved inline styles into CSS files and added semantic classes to containers",
-          "weight": 30,
-          "type": "style",
-          "scope": "layout"
-        }
-      ],
-      "changes-ru": [
-        {
-          "description": "Перенесены встроенные стили в CSS и добавлены семантические классы контейнерам",
-          "weight": 30,
-          "type": "style",
-          "scope": "layout"
-        }
-      ]
-    }
-  ]
-}
+      {
+        "version": "0.0.57",
+        "date": "2025-08-29",
+        "time": "17:05:00",
+        "timezone": "Asia/Bishkek",
+        "changes": [
+          {
+            "description": "Moved inline styles into CSS files and added semantic classes to containers",
+            "weight": 30,
+            "type": "style",
+            "scope": "layout"
+          }
+        ],
+        "changes-ru": [
+          {
+            "description": "Перенесены встроенные стили в CSS и добавлены семантические классы контейнерам",
+            "weight": 30,
+            "type": "style",
+            "scope": "layout"
+          }
+        ]
+      },
+      {
+        "version": "0.0.58",
+        "date": "2025-08-31",
+        "time": "06:15:00",
+        "timezone": "Asia/Bishkek",
+        "changes": [
+          {
+            "description": "Simplified release notes tags by replacing nested divs with spans",
+            "weight": 20,
+            "type": "refactor",
+            "scope": "release-notes"
+          }
+        ],
+        "changes-ru": [
+          {
+            "description": "Упрощены теги заметок релизов, заменены вложенные div на span",
+            "weight": 20,
+            "type": "refactor",
+            "scope": "release-notes"
+          }
+        ]
+      }
+    ]
+  }

--- a/src/user/pages/releaseNotesPage.css
+++ b/src/user/pages/releaseNotesPage.css
@@ -4,14 +4,14 @@
   flex-wrap: wrap;
 }
 
-.tags-variant-20 span {
+.tags-variant-20 {
   background: #000;
   color: #fff;
   text-shadow: 1px 1px 0 #333;
   padding: 2px 6px;
 }
 
-.tags-variant-21 span {
+.tags-variant-21 {
   border: 1px solid #000;
   padding: 2px 6px;
 }

--- a/src/user/pages/releaseNotesPage.jsx
+++ b/src/user/pages/releaseNotesPage.jsx
@@ -45,12 +45,8 @@ export default function ReleaseNotesPage() {
                     <li key={i}>
                       {ch.description}
                       <div className="tags">
-                        <div className="tags-variant-21">
-                          <span>{ch.type}</span>
-                        </div>
-                        <div className="tags-variant-20">
-                          <span>{ch.scope}</span>
-                        </div>
+                        <span className="tags-variant-21">{ch.type}</span>
+                        <span className="tags-variant-20">{ch.scope}</span>
                       </div>
                     </li>
                   ))}


### PR DESCRIPTION
## Summary
- replace nested divs in release notes tags with spans
- adjust tag styles and bump version to 0.0.58
- document markup refactor in release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b393a1f83c832ea93d626a9d32f4c0