### PR TITLE
fix: avoid nested main containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.58
+Current version: 0.0.59
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -121,6 +121,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 19. Контейнеры
  - [x] 19.1 Удалить лишние контейнеры div на страницах
+
+20. Семантика main
+ - [x] 20.1 Удалить вложенные контейнеры main из страниц
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.57",
+  "version": "0.0.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.57",
+    "version": "0.0.59",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.58",
+  "version": "0.0.59",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1481,6 +1481,28 @@
           "scope": "release-notes"
         }
       ]
+    },
+    {
+      "version": "0.0.59",
+      "date": "2025-08-31",
+      "time": "06:16:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Replaced nested main elements with sections for valid HTML structure",
+          "weight": 20,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заменены вложенные теги main на section для корректной структуры HTML",
+          "weight": 20,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2835,26 +2857,48 @@
         ]
       },
       {
-        "version": "0.0.58",
-        "date": "2025-08-31",
-        "time": "06:15:00",
-        "timezone": "Asia/Bishkek",
-        "changes": [
-          {
-            "description": "Simplified release notes tags by replacing nested divs with spans",
-            "weight": 20,
-            "type": "refactor",
-            "scope": "release-notes"
-          }
-        ],
-        "changes-ru": [
-          {
-            "description": "Упрощены теги заметок релизов, заменены вложенные div на span",
-            "weight": 20,
-            "type": "refactor",
-            "scope": "release-notes"
-          }
-        ]
-      }
-    ]
-  }
+      "version": "0.0.58",
+      "date": "2025-08-31",
+      "time": "06:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Simplified release notes tags by replacing nested divs with spans",
+          "weight": 20,
+          "type": "refactor",
+          "scope": "release-notes"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Упрощены теги заметок релизов, заменены вложенные div на span",
+          "weight": 20,
+          "type": "refactor",
+          "scope": "release-notes"
+        }
+      ]
+    },
+    {
+      "version": "0.0.59",
+      "date": "2025-08-31",
+      "time": "06:16:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Replaced nested main elements with sections for valid HTML structure",
+          "weight": 20,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заменены вложенные теги main на section для корректной структуры HTML",
+          "weight": 20,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ]
+    }
+  ]
+}

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -36,7 +36,7 @@ export default function AdminDashboardPage() {
   const period = `${labels[0]} to ${labels[labels.length - 1]}`
 
   return (
-    <main className="dashboard-page">
+    <section className="dashboard-page">
       <h1>{fullTitle}</h1>
       <section className="dashboard-grid">
         <Link to="/admin/charts/growth" className="dashboard-card">
@@ -56,6 +56,6 @@ export default function AdminDashboardPage() {
           <p>Goal: revenue | Source: events | Period: {period}</p>
         </Link>
       </section>
-    </main>
+    </section>
   )
 }

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -54,7 +54,7 @@ export default function AdminGraphEngagementPage() {
   })()
 
   return (
-    <main className="engagement-page">
+    <section className="engagement-page">
       <h1>{fullTitle}</h1>
       <section className="engagement-page__content">
         <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
@@ -78,6 +78,6 @@ export default function AdminGraphEngagementPage() {
         <Bar data={profileData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
         <p>Goal: platform profile | Source: users | Period: last 30 days</p>
       </section>
-    </main>
+    </section>
   )
 }

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -102,7 +102,7 @@ export default function AdminGraphGrowthPage() {
   }
 
   return (
-    <main className="growth-page">
+    <section className="growth-page">
       <h1>{fullTitle}</h1>
       <section className="growth-page__content">
         <Line data={areaData} options={{ stacked: true }} />
@@ -114,6 +114,6 @@ export default function AdminGraphGrowthPage() {
         <Bar data={weekdayData} />
         <p>Goal: seasonality | Source: events | Formula: aggregate by weekday | Period: all dates</p>
       </section>
-    </main>
+    </section>
   )
 }

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -57,7 +57,7 @@ export default function AdminGraphReliabilityPage() {
   }
 
   return (
-  <main className="reliability-page">
+  <section className="reliability-page">
       <h1>{fullTitle}</h1>
       <section className="reliability-page__content">
         <Line data={errRateData} />
@@ -69,6 +69,6 @@ export default function AdminGraphReliabilityPage() {
         <Bar data={pagesData} options={{ indexAxis: 'y' }} />
         <p>Goal: problematic pages | Source: events | Formula: type=error aggregated | Period: all dates</p>
       </section>
-    </main>
+    </section>
   )
 }

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -51,7 +51,7 @@ export default function AdminGraphRevenuePage() {
   }
 
   return (
-    <main className="revenue-page">
+    <section className="revenue-page">
       <h1>{fullTitle}</h1>
       <section className="revenue-page__content">
         <Bar data={funnelData} />
@@ -63,6 +63,6 @@ export default function AdminGraphRevenuePage() {
         <Line data={cumulativeData} />
         <p>Goal: user base growth | Source: users | Period: all dates</p>
       </section>
-    </main>
+    </section>
   )
 }

--- a/src/admin/pages/adminUiChartsPage.jsx
+++ b/src/admin/pages/adminUiChartsPage.jsx
@@ -557,7 +557,7 @@ export default function AdminUiChartsPage() {
   }
 
   return (
-    <main className="admin-ui-charts-page">
+    <section className="admin-ui-charts-page">
       <h1>{fullTitle}</h1>
       <AuthMessage />
       {chartExamples.map(({ title, description, render, code }) => (
@@ -565,7 +565,7 @@ export default function AdminUiChartsPage() {
           {render()}
         </ChartExample>
       ))}
-    </main>
+    </section>
   )
 }
 

--- a/src/user/pages/mainPage.jsx
+++ b/src/user/pages/mainPage.jsx
@@ -7,7 +7,7 @@ export default function MainPage() {
     document.title = 'ACPC'
   }, [])
   return (
-    <main className="main-page">
+    <section className="main-page">
       <h1>
         <img src="/icon.svg" alt="ACPC icon" className="main-page__icon" />
         ACPC
@@ -16,6 +16,6 @@ export default function MainPage() {
       <p>
         Go to <Link to="/admin">/admin</Link> to see.
       </p>
-    </main>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- replace nested `main` elements in user and admin pages with `section`
- document semantics task and bump version to 0.0.59
- record change in release notes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b399295934832ea544665fe1387d2c