### PR TITLE
feat: improve navigation accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.59
+Current version: 0.0.60
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-    "version": "0.0.59",
+    "version": "0.0.60",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.59",
+  "version": "0.0.60",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1503,6 +1503,28 @@
           "scope": "layout"
         }
       ]
+    },
+    {
+      "version": "0.0.60",
+      "date": "2025-08-31",
+      "time": "06:17:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added skip link and focus management and replaced clickable divs with buttons",
+          "weight": 30,
+          "type": "feat",
+          "scope": "a11y"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены ссылка пропуска, управление фокусом и замена кликабельных div на кнопки",
+          "weight": 30,
+          "type": "feat",
+          "scope": "a11y"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2897,6 +2919,28 @@
           "weight": 20,
           "type": "fix",
           "scope": "layout"
+        }
+      ]
+    },
+    {
+      "version": "0.0.60",
+      "date": "2025-08-31",
+      "time": "06:17:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added skip link and focus management and replaced clickable divs with buttons",
+          "weight": 30,
+          "type": "feat",
+          "scope": "a11y"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлены ссылка пропуска, управление фокусом и замена кликабельных div на кнопки",
+          "weight": 30,
+          "type": "feat",
+          "scope": "a11y"
         }
       ]
     }

--- a/src/admin/app/barLeftAdmin.css
+++ b/src/admin/app/barLeftAdmin.css
@@ -41,6 +41,10 @@
   cursor: pointer;
   transition: background-color 0.3s ease;
   color: var(--color-text);
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
 }
 .icon-button:hover {
   background-color: var(--color-hover);

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -64,14 +64,16 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
   return (
     <aside className={`sidebar-left ${isCollapsed ? 'collapsed' : ''}`} onMouseLeave={onMouseLeave}>
       <div className="sidebar-header">
-        <div
+        <button
+          type="button"
           className={`icon-button${disableToggle ? ' disabled' : ''}`}
           onMouseEnter={disableToggle ? undefined : onIconEnter}
           onClick={disableToggle ? undefined : toggle}
-          title="Toggle sidebar"
+          aria-label="Toggle sidebar"
+          disabled={disableToggle}
         >
           <Sidebar size={16} />
-        </div>
+        </button>
         {!isCollapsed && (
           <>
             <Link to="/" className="icon-button" title="Home">
@@ -94,7 +96,7 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
       </div>
       {!isCollapsed && (
         <>
-          <nav className="sidebar-content">
+          <nav className="sidebar-content" aria-label="Main navigation">
             <ul>
               {flatNodes.map(node => (
                 <li key={node.path}>

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -8,6 +8,26 @@
   padding: 16px;
 }
 
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  padding: 8px;
+  background: var(--color-surface);
+  outline: 2px solid var(--color-text);
+  z-index: 1000;
+}
+
 .acph-section {}
 
 .acph-section.is-collapsed {

--- a/src/admin/app/layout.jsx
+++ b/src/admin/app/layout.jsx
@@ -1,5 +1,5 @@
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import useCollapsibleHeadings from './hooks/useCollapsibleHeadings.js'
 import BarLeftAdmin from './barLeftAdmin.jsx'
 import { isAdminAuth } from './auth.js'
@@ -10,6 +10,7 @@ export default function Layout() {
   const location = useLocation()
   const navigate = useNavigate()
   const isLogin = location.pathname === '/admin/login'
+  const mainRef = useRef(null)
 
   useEffect(() => {
     if (!isLogin && !isAdminAuth()) {
@@ -18,15 +19,22 @@ export default function Layout() {
     }
   }, [isLogin, navigate, location])
 
+  useEffect(() => {
+    mainRef.current?.focus()
+  }, [location])
+
   useCollapsibleHeadings()
 
   return (
-    <div className="layout">
-      <BarLeftAdmin forceCollapsed={isLogin} disableToggle={isLogin} />
-      <main>
-        <Outlet />
-        <SubPages />
-      </main>
-    </div>
+    <>
+      <a href="#main" className="skip-link">Skip to main content</a>
+      <div className="layout">
+        <BarLeftAdmin forceCollapsed={isLogin} disableToggle={isLogin} />
+        <main id="main" tabIndex={-1} ref={mainRef}>
+          <Outlet />
+          <SubPages />
+        </main>
+      </div>
+    </>
   )
 }

--- a/src/user/app/barLeftUser.css
+++ b/src/user/app/barLeftUser.css
@@ -38,6 +38,10 @@
   cursor: pointer;
   transition: background-color 0.3s ease;
   color: var(--color-text);
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
 }
 .icon-button:hover {
   background-color: var(--color-hover);

--- a/src/user/app/barLeftUser.jsx
+++ b/src/user/app/barLeftUser.jsx
@@ -61,14 +61,15 @@ export default function BarLeftUser() {
   return (
     <aside className={`sidebar-left ${isCollapsed ? 'collapsed' : ''}`} onMouseLeave={onMouseLeave}>
       <div className="sidebar-header">
-        <div
+        <button
+          type="button"
           className="icon-button"
           onMouseEnter={onIconEnter}
           onClick={toggle}
-          title="Toggle sidebar"
+          aria-label="Toggle sidebar"
         >
           <Sidebar size={16} />
-        </div>
+        </button>
         {!isCollapsed && (
           <>
             <Link to="/" className="icon-button" title="Home">
@@ -89,7 +90,11 @@ export default function BarLeftUser() {
           </>
         )}
       </div>
-      {!isCollapsed && <nav className="sidebar-content">{renderTree(publicTree)}</nav>}
+      {!isCollapsed && (
+        <nav className="sidebar-content" aria-label="Main navigation">
+          {renderTree(publicTree)}
+        </nav>
+      )}
     </aside>
   )
 }

--- a/src/user/app/layout.css
+++ b/src/user/app/layout.css
@@ -7,3 +7,23 @@
   flex: 1;
   padding: 16px;
 }
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  padding: 8px;
+  background: var(--color-surface);
+  outline: 2px solid var(--color-text);
+  z-index: 1000;
+}

--- a/src/user/app/layout.jsx
+++ b/src/user/app/layout.jsx
@@ -1,14 +1,25 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
+import { useEffect, useRef } from 'react'
 import BarLeftUser from './barLeftUser.jsx'
 import './layout.css'
 
 export default function Layout() {
+  const location = useLocation()
+  const mainRef = useRef(null)
+
+  useEffect(() => {
+    mainRef.current?.focus()
+  }, [location])
+
   return (
-    <div className="layout">
-      <BarLeftUser />
-      <main>
-        <Outlet />
-      </main>
-    </div>
+    <>
+      <a href="#main" className="skip-link">Skip to main content</a>
+      <div className="layout">
+        <BarLeftUser />
+        <main id="main" tabIndex={-1} ref={mainRef}>
+          <Outlet />
+        </main>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add skip link and focus management for main content in user and admin layouts
- replace clickable divs with buttons and label navigation regions
- document accessibility changes in release notes and bump version to 0.0.60

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3adda2218832e814685e5e144951d