### PR TITLE
feat(admin): show app version in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.60
+Current version: 0.0.61
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -115,6 +115,7 @@ _Only this section of the readme can be maintained using Russian language_
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле
  - [x] 17.2 Добавить переключатель URL/Name в админском сайдбаре
+ - [x] 17.3 Вывести версию приложения в сайдбаре админа
 
 18. Семантическая разметка
  - [x] 18.1 Добавить классы контейнерам и вынести стили в CSS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-    "version": "0.0.60",
+      "version": "0.0.61",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.60",
+  "version": "0.0.61",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1525,6 +1525,28 @@
           "scope": "a11y"
         }
       ]
+    },
+    {
+      "version": "0.0.61",
+      "date": "2025-08-31",
+      "time": "06:18:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added application version above toggle in admin sidebar",
+          "weight": 20,
+          "type": "feat",
+          "scope": "admin-ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Выведена версия приложения над переключателем в сайдбаре админа",
+          "weight": 20,
+          "type": "feat",
+          "scope": "admin-ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2941,6 +2963,28 @@
           "weight": 30,
           "type": "feat",
           "scope": "a11y"
+        }
+      ]
+    },
+    {
+      "version": "0.0.61",
+      "date": "2025-08-31",
+      "time": "06:18:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added application version above toggle in admin sidebar",
+          "weight": 20,
+          "type": "feat",
+          "scope": "admin-ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Выведена версия приложения над переключателем в сайдбаре админа",
+          "weight": 20,
+          "type": "feat",
+          "scope": "admin-ui"
         }
       ]
     }

--- a/src/admin/app/barLeftAdmin.css
+++ b/src/admin/app/barLeftAdmin.css
@@ -85,3 +85,7 @@
   gap: 4px;
   cursor: pointer;
 }
+
+.sidebar-version {
+  text-align: right;
+}

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { Sidebar, Home, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
+import pkg from '../../../package.json'
 import urlTree from '../../urlTree.json'
 import './barLeftAdmin.css'
 
@@ -111,6 +112,7 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
               ))}
             </ul>
           </nav>
+          <div className="sidebar-footer sidebar-version">v{pkg.version}</div>
           <div className="sidebar-footer">
             <label>
               <input type="checkbox" checked={showNames} onChange={toggleNames} />


### PR DESCRIPTION
## Summary
- display current application version above admin sidebar toggle with right alignment
- bump version to 0.0.61 and document in README and release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3e8f0ebac832eaed555e819fe7946