### PR TITLE
style: remove focus outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.62
+Current version: 0.0.63
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -125,6 +125,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 20. Семантика main
  - [x] 20.1 Удалить вложенные контейнеры main из страниц
+
+21. Фокус
+  - [x] 21.1 Отключить обводку при фокусе
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.61",
+  "version": "0.0.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.61",
+      "version": "0.0.63",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.62",
+  "version": "0.0.63",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1569,6 +1569,28 @@
           "scope": "admin-ui"
         }
       ]
+    },
+    {
+      "version": "0.0.63",
+      "date": "2025-08-31",
+      "time": "06:28:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Removed focus outlines from interactive elements",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Удалены обводки фокуса с интерактивных элементов",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3029,6 +3051,28 @@
           "weight": 40,
           "type": "fix",
           "scope": "admin-ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.63",
+      "date": "2025-08-31",
+      "time": "06:28:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Removed focus outlines from interactive elements",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Удалены обводки фокуса с интерактивных элементов",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
         }
       ]
     }

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -24,7 +24,6 @@
   height: auto;
   padding: 8px;
   background: var(--color-surface);
-  outline: 2px solid var(--color-text);
   z-index: 1000;
 }
 
@@ -42,6 +41,3 @@
     margin-right: 5px;  
 }
 
-.acph-toggle:focus {
-  outline: 2px solid currentColor;
-}

--- a/src/index.css
+++ b/src/index.css
@@ -95,9 +95,8 @@ button:hover {
   border-color: var(--color-link);
 }
 
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+:focus {
+  outline: none;
 }
 
   h1 {

--- a/src/user/app/layout.css
+++ b/src/user/app/layout.css
@@ -24,6 +24,5 @@
   height: auto;
   padding: 8px;
   background: var(--color-surface);
-  outline: 2px solid var(--color-text);
   z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- remove focus outlines by disabling outline on focus and skipping element-specific outlines
- bump version to 0.0.63 and document release

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3ed802b78832ebcbe12a92f3a1787