### PR TITLE
Remove ACPC suffix from page headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.64
+Current version: 0.0.65
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -130,6 +130,9 @@ _Only this section of the readme can be maintained using Russian language_
 21. Фокус
   - [x] 21.1 Отключить обводку при фокусе
 
+22. Заголовки
+ - [x] 22.1 Удалить сегмент " | ACPC" из h1 всех страниц
+
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.
 2. Maintain a hierarchical task list with consistent numbering.
@@ -164,7 +167,7 @@ _Only this section of the readme can be maintained using Russian language_
 - JavaScript only (no TypeScript).
 - No remote databases and no custom backend.
 - Demo data must come from local sources (in-memory, JSON, or localStorage).
-- Every page uses a single `<h1>` mirrored in the document title; non-home pages append " | ACPC".
+- Every page uses a single `<h1>` mirrored in the document title; document titles append " | ACPC".
 
 ## Tech and infrastructure
 - React + Vite (fast HMR).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.64",
+  "version": "0.0.65",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1613,6 +1613,28 @@
           "scope": "routing"
         }
       ]
+    },
+    {
+      "version": "0.0.65",
+      "date": "2025-08-31",
+      "time": "12:57:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Removed site name segment from page headings",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Удалён сегмент названия сайта из заголовков страниц",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3117,6 +3139,28 @@
           "weight": 40,
           "type": "feat",
           "scope": "routing"
+        }
+      ]
+    },
+    {
+      "version": "0.0.65",
+      "date": "2025-08-31",
+      "time": "12:57:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Removed site name segment from page headings",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Удалён сегмент названия сайта из заголовков страниц",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
         }
       ]
     }

--- a/src/admin/pages/adminDashboardPage.jsx
+++ b/src/admin/pages/adminDashboardPage.jsx
@@ -7,7 +7,8 @@ import './adminDashboardPage.css'
 
 export default function AdminDashboardPage() {
   const title = 'Dashboard'
-  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
   const outlet = useOutlet()
   const [data, setData] = useState(null)
 
@@ -37,7 +38,7 @@ export default function AdminDashboardPage() {
 
   return (
     <section className="dashboard-page">
-      <h1>{fullTitle}</h1>
+      <h1>{heading}</h1>
       <section className="dashboard-grid">
         <Link to="/admin/growth" className="dashboard-card">
           <Line data={dauData} options={commonLineOpts} />

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -6,7 +6,8 @@ import './adminGraphEngagementPage.css'
 
 export default function AdminGraphEngagementPage() {
   const title = 'Engagement Metrics'
-  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
   const [data, setData] = useState(null)
 
   useEffect(() => { document.title = fullTitle }, [fullTitle])
@@ -55,7 +56,7 @@ export default function AdminGraphEngagementPage() {
 
   return (
     <section className="engagement-page">
-      <h1>{fullTitle}</h1>
+      <h1>{heading}</h1>
       <section className="engagement-page__content">
         <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
         <p>Goal: load vs conversion | Source: activity | Formula: signups/visits Δ to conversion | Period: all dates</p>

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -6,7 +6,8 @@ import './adminGraphGrowthPage.css'
 
 export default function AdminGraphGrowthPage() {
   const title = 'Growth Metrics'
-  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
   const [data, setData] = useState(null)
 
   useEffect(() => {
@@ -103,7 +104,7 @@ export default function AdminGraphGrowthPage() {
 
   return (
     <section className="growth-page">
-      <h1>{fullTitle}</h1>
+      <h1>{heading}</h1>
       <section className="growth-page__content">
         <Line data={areaData} options={{ stacked: true }} />
         <p>Goal: compare active audiences | Source: events | Formula: DAU/WAU/MAU/SMA7 | Period: all dates</p>

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -6,7 +6,8 @@ import './adminGraphReliabilityPage.css'
 
 export default function AdminGraphReliabilityPage() {
   const title = 'Reliability Metrics'
-  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
   const [data, setData] = useState(null)
 
   useEffect(() => { document.title = fullTitle }, [fullTitle])
@@ -58,7 +59,7 @@ export default function AdminGraphReliabilityPage() {
 
   return (
   <section className="reliability-page">
-      <h1>{fullTitle}</h1>
+      <h1>{heading}</h1>
       <section className="reliability-page__content">
         <Line data={errRateData} />
         <p>Goal: stability per session | Source: activity | Formula: errors/sessions | Period: all dates</p>

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -6,7 +6,8 @@ import './adminGraphRevenuePage.css'
 
 export default function AdminGraphRevenuePage() {
   const title = 'Revenue Metrics'
-  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
   const [data, setData] = useState(null)
 
   useEffect(() => { document.title = fullTitle }, [fullTitle])
@@ -52,7 +53,7 @@ export default function AdminGraphRevenuePage() {
 
   return (
     <section className="revenue-page">
-      <h1>{fullTitle}</h1>
+      <h1>{heading}</h1>
       <section className="revenue-page__content">
         <Bar data={funnelData} />
         <p>Goal: step drop-off | Source: events | Formula: funnel totals | Period: all dates</p>

--- a/src/admin/pages/adminUiChartsPage.jsx
+++ b/src/admin/pages/adminUiChartsPage.jsx
@@ -12,7 +12,8 @@ const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#413ea0', '#ff0000'
 
 export default function AdminUiChartsPage() {
   const title = 'Admin UI Charts Page'
-  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
   const [users, setUsers] = useState([])
 
   useEffect(() => {
@@ -558,7 +559,7 @@ export default function AdminUiChartsPage() {
 
   return (
     <section className="admin-ui-charts-page">
-      <h1>{fullTitle}</h1>
+      <h1>{heading}</h1>
       <AuthMessage />
       {chartExamples.map(({ title, description, render, code }) => (
         <ChartExample key={title} title={title} description={description} code={code}>

--- a/src/admin/pages/adminUiPage.jsx
+++ b/src/admin/pages/adminUiPage.jsx
@@ -5,7 +5,8 @@ import './adminUiPage.css'
 
 export default function AdminUiPage() {
   const title = 'Admin UI'
-  const fullTitle = `${title} | Admin Control Panel | ACPC`
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
   const outlet = useOutlet()
   useEffect(() => {
     document.title = fullTitle
@@ -21,7 +22,7 @@ export default function AdminUiPage() {
 
   return (
     <>
-      <h1>{fullTitle}</h1>
+      <h1>{heading}</h1>
       <AuthMessage />
 
       <h2>Login form variants</h2>


### PR DESCRIPTION
## Summary
- Drop `| ACPC` suffix from all admin page `<h1>` headings while retaining it in document titles
- Document new heading rule and bump version to 0.0.65
- Record the change in release notes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b3f1d69ca0832e80a737311f4217a3