### PR TITLE
style: refine collapsible heading toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.65
+Current version: 0.0.66
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -112,6 +112,7 @@ _Only this section of the readme can be maintained using Russian language_
 
 16. Collapsible headings
  - [x] 16.1 Enable collapsible headings in admin pages
+ - [x] 16.2 Adjust toggle size for h3 and remove hover border
 
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.65",
+  "version": "0.0.66",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1635,6 +1635,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.66",
+      "date": "2025-08-31",
+      "time": "13:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Refined collapsible heading toggle sizing and hover brightness",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Уточнены размеры переключателя заголовков и яркость при наведении",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3159,6 +3181,28 @@
         {
           "description": "Удалён сегмент названия сайта из заголовков страниц",
           "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.66",
+      "date": "2025-08-31",
+      "time": "13:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Refined collapsible heading toggle sizing and hover brightness",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Уточнены размеры переключателя заголовков и яркость при наведении",
+          "weight": 30,
           "type": "style",
           "scope": "ui"
         }

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -35,9 +35,23 @@
 .acph-toggle {
   cursor: pointer;
   user-select: none;
+  font-size: 10px;
+  vertical-align: text-bottom;
+  margin-right: 5px;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background: none;
+  color: inherit;
+  transition: filter 0.2s;
+}
 
-    font-size: 10px;
-    vertical-align: text-bottom;
-    margin-right: 5px;  
+h3 > .acph-toggle {
+  font-size: 8px;
+}
+
+.acph-toggle:hover {
+  border: none;
+  filter: brightness(1.2);
 }
 


### PR DESCRIPTION
## Summary
- make h3 collapsible heading toggles smaller than h2
- remove hover border on collapsible toggles and add brightness change
- record changes in docs and release notes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3f426e2b4832e9229c0ce2ba52a9b