### PR TITLE
Hide admin subpages on dashboard and collapse charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.66
+Current version: 0.0.67
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -11,11 +11,12 @@ Current version: 0.0.66
 - Public pages use a collapsible sidebar with icon tooltips and home link
 - Admin pages have a separate collapsible menu
 - Code split between `src/user` and `src/admin`
-- Admin pages display "Subpages" with a full URL tree when subpages exist
+- Admin pages (except the dashboard) display "Subpages" with a full URL tree when subpages exist
 - Navigation sidebars derive from the same tree; admin lists all URLs flat (no nested lists), public lists non-admin URLs
 - User and admin sidebars highlight the active link
 - Dashboard at `/admin` with mini charts for growth, engagement, reliability, and revenue
 - Detailed analytics pages at `/admin/*` for growth, engagement, reliability, and revenue
+- Analytics charts use collapsible h3 headings for easier browsing
 - Chart.js users charts at `/admin/ui/charts`
 
 # ACP+Charts сomming soon
@@ -134,6 +135,9 @@ _Only this section of the readme can be maintained using Russian language_
 22. Заголовки
  - [x] 22.1 Удалить сегмент " | ACPC" из h1 всех страниц
 
+23. Admin subpages
+ - [x] 23.1 Hide Subpages on the dashboard
+
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.
 2. Maintain a hierarchical task list with consistent numbering.
@@ -153,11 +157,11 @@ _Only this section of the readme can be maintained using Russian language_
 12. If there is no indication what language the page should be in, use English.
 13. Update `release-notes.json` for every user-facing change according to `release-notes-howto.md`. Assign a weight between 20 and 80 and bump the PATCH version when cutting a release.
 14. Keep user and admin code separated in `/src/user` and `/src/admin`, each containing its own `app` and `pages` directories. Allow duplication between them but record every instance in the "Code duplication log" section.
-15. The admin layout automatically renders the `SubPages` component at the end of every `/admin` route; admin pages should not render `SubPages` themselves to avoid duplication, and the component shows the "Subpages" heading only when subpages exist.
+15. The admin layout automatically renders the `SubPages` component at the end of `/admin/*` routes except the dashboard root `/admin`; admin pages should not render `SubPages` themselves to avoid duplication, and the component shows the "Subpages" heading only when subpages exist.
 16. After each task, re-check navigation (see Verification steps).
 
 # Verification steps
-1. Open several pages: /admin, /admin/section, /admin/section/subsection — confirm each shows "Subpages" at the bottom with the full tree.
+1. Open /admin, /admin/section, /admin/section/subsection — confirm only nested routes show "Subpages" at the bottom with the full tree.
 2. Check the admin left sidebar — all URLs present and shown flat (no nested lists).
 3. Check the public site left sidebar — all URLs present except /admin and its descendants.
 4. After any page structure change, repeat steps 1–3.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.66",
+  "version": "0.0.67",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1657,6 +1657,40 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.67",
+      "date": "2025-08-31",
+      "time": "13:22:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Removed subpage list from admin dashboard",
+          "weight": 30,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Added collapsible headings to analytics charts",
+          "weight": 40,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Убран список подстраниц на админской главной",
+          "weight": 30,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Перед графиками аналитики добавлены сворачиваемые заголовки",
+          "weight": 40,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -2988,29 +3022,29 @@
         }
       ]
     },
-      {
-        "version": "0.0.57",
-        "date": "2025-08-29",
-        "time": "17:05:00",
-        "timezone": "Asia/Bishkek",
-        "changes": [
-          {
-            "description": "Moved inline styles into CSS files and added semantic classes to containers",
-            "weight": 30,
-            "type": "style",
-            "scope": "layout"
-          }
-        ],
-        "changes-ru": [
-          {
-            "description": "Перенесены встроенные стили в CSS и добавлены семантические классы контейнерам",
-            "weight": 30,
-            "type": "style",
-            "scope": "layout"
-          }
-        ]
-      },
-      {
+    {
+      "version": "0.0.57",
+      "date": "2025-08-29",
+      "time": "17:05:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Moved inline styles into CSS files and added semantic classes to containers",
+          "weight": 30,
+          "type": "style",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Перенесены встроенные стили в CSS и добавлены семантические классы контейнерам",
+          "weight": 30,
+          "type": "style",
+          "scope": "layout"
+        }
+      ]
+    },
+    {
       "version": "0.0.58",
       "date": "2025-08-31",
       "time": "06:15:00",
@@ -3204,6 +3238,40 @@
           "description": "Уточнены размеры переключателя заголовков и яркость при наведении",
           "weight": 30,
           "type": "style",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.67",
+      "date": "2025-08-31",
+      "time": "13:22:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Removed subpage list from admin dashboard",
+          "weight": 30,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Added collapsible headings to analytics charts",
+          "weight": 40,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Убран список подстраниц на админской главной",
+          "weight": 30,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Перед графиками аналитики добавлены сворачиваемые заголовки",
+          "weight": 40,
+          "type": "feat",
           "scope": "ui"
         }
       ]

--- a/src/admin/app/layout.jsx
+++ b/src/admin/app/layout.jsx
@@ -32,7 +32,7 @@ export default function Layout() {
         <BarLeftAdmin forceCollapsed={isLogin} disableToggle={isLogin} />
         <main id="main" tabIndex={-1} ref={mainRef}>
           <Outlet />
-          <SubPages />
+          {location.pathname !== '/admin' && <SubPages />}
         </main>
       </div>
     </>

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -58,10 +58,13 @@ export default function AdminGraphEngagementPage() {
     <section className="engagement-page">
       <h1>{heading}</h1>
       <section className="engagement-page__content">
+        <h3>Sessions vs conversion</h3>
         <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
         <p>Goal: load vs conversion | Source: activity | Formula: signups/visits Δ to conversion | Period: all dates</p>
+        <h3>Stickiness</h3>
         <Line data={stickinessData} />
         <p>Goal: product stickiness | Source: events | Formula: DAU/MAU | Period: all dates</p>
+        <h3>Cohort retention</h3>
         <table className="engagement-page__table">
           <thead><tr><th>Week</th><th>d+7</th><th>d+14</th><th>d+28</th></tr></thead>
           <tbody>
@@ -76,6 +79,7 @@ export default function AdminGraphEngagementPage() {
           </tbody>
         </table>
         <p>Goal: cohort retention | Source: users | Formula: activity at d+N | Period: all cohorts</p>
+        <h3>Platform profile</h3>
         <Bar data={profileData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
         <p>Goal: platform profile | Source: users | Period: last 30 days</p>
       </section>

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -61,12 +61,16 @@ export default function AdminGraphReliabilityPage() {
   <section className="reliability-page">
       <h1>{heading}</h1>
       <section className="reliability-page__content">
+        <h3>Error rate</h3>
         <Line data={errRateData} />
         <p>Goal: stability per session | Source: activity | Formula: errors/sessions | Period: all dates</p>
+        <h3>Error codes stack</h3>
         <Line data={stackedErrorsData} options={{ stacked: true }} />
         <p>Goal: incident structure | Source: activity | Formula: errors by code | Period: all dates</p>
+        <h3>Pareto of errors</h3>
         <Bar data={paretoData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
         <p>Goal: 80/20 principle | Source: activity | Period: all dates</p>
+        <h3>Top error pages</h3>
         <Bar data={pagesData} options={{ indexAxis: 'y' }} />
         <p>Goal: problematic pages | Source: events | Formula: type=error aggregated | Period: all dates</p>
       </section>

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -55,12 +55,16 @@ export default function AdminGraphRevenuePage() {
     <section className="revenue-page">
       <h1>{heading}</h1>
       <section className="revenue-page__content">
+        <h3>Funnel conversion</h3>
         <Bar data={funnelData} />
         <p>Goal: step drop-off | Source: events | Formula: funnel totals | Period: all dates</p>
+        <h3>Paying segments</h3>
         <Bar data={segData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
         <p>Goal: paying segments | Source: events+users | Period: all subs</p>
+        <h3>Signups vs subscriptions</h3>
         <Bar data={signupSubData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right' } } }} />
         <p>Goal: inflow vs paid conversions | Source: activity+events | Period: all dates</p>
+        <h3>Cumulative users</h3>
         <Line data={cumulativeData} />
         <p>Goal: user base growth | Source: users | Period: all dates</p>
       </section>


### PR DESCRIPTION
## Summary
- Hide the Subpages section on the admin dashboard
- Add collapsible h3 headings before charts on engagement, reliability, and revenue pages
- Document changes and bump version to 0.0.67

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3f786967c832eb8351b47ce461364