### PR TITLE
feat: add collapsible heading design variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ACP+Charts now
-Current version: 0.0.67
+Current version: 0.0.68
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
 - Admin login at `/admin/login` using env credentials
 - Authenticated admins visiting `/admin/login` are redirected back to the previous page
-- Admin access to dashboard, analytics graphs, and UI demos of 30 forms and 30 hashtags
+- Admin access to dashboard, analytics graphs, and UI demos of 30 forms, 30 hashtags, and 20 collapsible heading designs
 - Logout at `/admin/logout` with redirect for unauthenticated routes
 - Return to originally requested admin page after login
 - Public pages use a collapsible sidebar with icon tooltips and home link
@@ -137,6 +137,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 23. Admin subpages
  - [x] 23.1 Hide Subpages on the dashboard
+
+24. Collapsible heading variants
+ - [x] 24.1 Create 20 button style options for collapsible h2 and h3 headings
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.66",
+  "version": "0.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.66",
+      "version": "0.0.68",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.67",
+  "version": "0.0.68",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1691,6 +1691,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.68",
+      "date": "2025-08-31",
+      "time": "13:44:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added 20 minimal button styles for collapsible h2 and h3 headings",
+          "weight": 40,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено 20 минималистичных стилей кнопок для сворачиваемых заголовков h2 и h3",
+          "weight": 40,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3270,6 +3292,28 @@
         },
         {
           "description": "Перед графиками аналитики добавлены сворачиваемые заголовки",
+          "weight": 40,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.68",
+      "date": "2025-08-31",
+      "time": "13:44:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added 20 minimal button styles for collapsible h2 and h3 headings",
+          "weight": 40,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено 20 минималистичных стилей кнопок для сворачиваемых заголовков h2 и h3",
           "weight": 40,
           "type": "feat",
           "scope": "ui"

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -1,4 +1,5 @@
 import AdminUiChartsPage from '../pages/adminUiChartsPage.jsx'
+import AdminUiHeadingsPage from '../pages/adminUiHeadingsPage.jsx'
 import AdminUiPage from '../pages/adminUiPage.jsx'
 import AdminLoginPage from '../pages/adminLoginPage.jsx'
 import AdminLogoutPage from '../pages/adminLogoutPage.jsx'
@@ -21,6 +22,7 @@ const adminRoutes = [
     element: <AdminUiPage />,
     label: 'UI',
     children: [
+      { path: 'headings', element: <AdminUiHeadingsPage />, label: 'Headings' },
       { path: 'charts', element: <AdminUiChartsPage />, label: 'Charts' }
     ]
   },

--- a/src/admin/pages/adminUiHeadingsPage.css
+++ b/src/admin/pages/adminUiHeadingsPage.css
@@ -1,0 +1,312 @@
+.heading-demo {
+  margin-bottom: 16px;
+}
+
+.heading-demo .acph-toggle {
+  width: 1.2em;
+  height: 1.2em;
+  margin-right: 6px;
+  font-size: 0;
+  line-height: 1.2em;
+  position: relative;
+  background: none;
+  border: none;
+}
+
+.heading-demo .acph-toggle::before,
+.heading-demo .acph-toggle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.heading-demo .acph-toggle::after {
+  display: none;
+}
+
+/* Variant 1: square plus/minus */
+.variant-1 .acph-toggle {
+  border: 1px solid currentColor;
+}
+.variant-1 .acph-toggle::before {
+  content: '+';
+  font-size: 0.8em;
+}
+.variant-1 .acph-toggle[aria-expanded="true"]::before {
+  content: '−';
+}
+
+/* Variant 2: circle plus/minus */
+.variant-2 .acph-toggle {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+.variant-2 .acph-toggle::before {
+  content: '+';
+  font-size: 0.8em;
+}
+.variant-2 .acph-toggle[aria-expanded="true"]::before {
+  content: '−';
+}
+
+/* Variant 3: filled square plus/minus */
+.variant-3 .acph-toggle {
+  background: currentColor;
+  color: var(--color-bg);
+}
+.variant-3 .acph-toggle::before {
+  content: '+';
+  font-size: 0.8em;
+  color: var(--color-bg);
+}
+.variant-3 .acph-toggle[aria-expanded="true"]::before {
+  content: '−';
+}
+
+/* Variant 4: filled circle plus/minus */
+.variant-4 .acph-toggle {
+  background: currentColor;
+  color: var(--color-bg);
+  border-radius: 50%;
+}
+.variant-4 .acph-toggle::before {
+  content: '+';
+  font-size: 0.8em;
+  color: var(--color-bg);
+}
+.variant-4 .acph-toggle[aria-expanded="true"]::before {
+  content: '−';
+}
+
+/* Variant 5: bare plus/minus */
+.variant-5 .acph-toggle::before {
+  content: '+';
+  font-size: 0.8em;
+}
+.variant-5 .acph-toggle[aria-expanded="true"]::before {
+  content: '−';
+}
+
+/* Variant 6: bare arrow */
+.variant-6 .acph-toggle::before {
+  content: '▶';
+  font-size: 0.8em;
+}
+.variant-6 .acph-toggle[aria-expanded="true"]::before {
+  content: '▼';
+}
+
+/* Variant 7: square arrow */
+.variant-7 .acph-toggle {
+  border: 1px solid currentColor;
+}
+.variant-7 .acph-toggle::before {
+  content: '▶';
+  font-size: 0.8em;
+}
+.variant-7 .acph-toggle[aria-expanded="true"]::before {
+  content: '▼';
+}
+
+/* Variant 8: circle arrow */
+.variant-8 .acph-toggle {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+.variant-8 .acph-toggle::before {
+  content: '▶';
+  font-size: 0.8em;
+}
+.variant-8 .acph-toggle[aria-expanded="true"]::before {
+  content: '▼';
+}
+
+/* Variant 9: bare chevron */
+.variant-9 .acph-toggle::before {
+  content: '>'; 
+  font-size: 0.8em;
+}
+.variant-9 .acph-toggle[aria-expanded="true"]::before {
+  content: 'v';
+}
+
+/* Variant 10: square chevron */
+.variant-10 .acph-toggle {
+  border: 1px solid currentColor;
+}
+.variant-10 .acph-toggle::before {
+  content: '>';
+  font-size: 0.8em;
+}
+.variant-10 .acph-toggle[aria-expanded="true"]::before {
+  content: 'v';
+}
+
+/* Variant 11: circle chevron */
+.variant-11 .acph-toggle {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+.variant-11 .acph-toggle::before {
+  content: '>';
+  font-size: 0.8em;
+}
+.variant-11 .acph-toggle[aria-expanded="true"]::before {
+  content: 'v';
+}
+
+/* Variant 12: bare triangle */
+.variant-12 .acph-toggle::before {
+  width: 0;
+  height: 0;
+  border-left: 6px solid currentColor;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+}
+.variant-12 .acph-toggle[aria-expanded="true"]::before {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 6px solid currentColor;
+  border-bottom: 0;
+}
+
+/* Variant 13: square triangle */
+.variant-13 .acph-toggle {
+  border: 1px solid currentColor;
+}
+.variant-13 .acph-toggle::before {
+  width: 0;
+  height: 0;
+  border-left: 6px solid currentColor;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+}
+.variant-13 .acph-toggle[aria-expanded="true"]::before {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 6px solid currentColor;
+  border-bottom: 0;
+}
+
+/* Variant 14: circle triangle */
+.variant-14 .acph-toggle {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+.variant-14 .acph-toggle::before {
+  width: 0;
+  height: 0;
+  border-left: 6px solid currentColor;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+}
+.variant-14 .acph-toggle[aria-expanded="true"]::before {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 6px solid currentColor;
+  border-bottom: 0;
+}
+
+/* Variant 15: plus to cross */
+.variant-15 .acph-toggle::before,
+.variant-15 .acph-toggle::after {
+  display: block;
+  width: 8px;
+  height: 2px;
+  background: currentColor;
+}
+.variant-15 .acph-toggle::before {
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+.variant-15 .acph-toggle::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+.variant-15 .acph-toggle[aria-expanded="true"]::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+.variant-15 .acph-toggle[aria-expanded="true"]::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+/* Variant 16: square plus to minus */
+.variant-16 .acph-toggle {
+  border: 1px solid currentColor;
+}
+.variant-16 .acph-toggle::before,
+.variant-16 .acph-toggle::after {
+  display: block;
+  width: 8px;
+  height: 2px;
+  background: currentColor;
+}
+.variant-16 .acph-toggle::before {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+.variant-16 .acph-toggle::after {
+  transform: translate(-50%, -50%);
+}
+.variant-16 .acph-toggle[aria-expanded="true"]::before {
+  display: none;
+}
+
+/* Variant 17: circle plus to minus */
+.variant-17 .acph-toggle {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+.variant-17 .acph-toggle::before,
+.variant-17 .acph-toggle::after {
+  display: block;
+  width: 8px;
+  height: 2px;
+  background: currentColor;
+}
+.variant-17 .acph-toggle::before {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+.variant-17 .acph-toggle::after {
+  transform: translate(-50%, -50%);
+}
+.variant-17 .acph-toggle[aria-expanded="true"]::before {
+  display: none;
+}
+
+/* Variant 18: rotating line */
+.variant-18 .acph-toggle::before {
+  display: block;
+  width: 8px;
+  height: 2px;
+  background: currentColor;
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+.variant-18 .acph-toggle[aria-expanded="false"]::before {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+/* Variant 19: bracket plus/minus */
+.variant-19 .acph-toggle::before {
+  content: '[+]';
+  font-size: 0.8em;
+}
+.variant-19 .acph-toggle[aria-expanded="true"]::before {
+  content: '[-]';
+}
+
+/* Variant 20: circle dot to line */
+.variant-20 .acph-toggle {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+.variant-20 .acph-toggle::before {
+  width: 4px;
+  height: 4px;
+  background: currentColor;
+  border-radius: 50%;
+}
+.variant-20 .acph-toggle[aria-expanded="true"]::before {
+  width: 8px;
+  height: 2px;
+  border-radius: 0;
+}

--- a/src/admin/pages/adminUiHeadingsPage.jsx
+++ b/src/admin/pages/adminUiHeadingsPage.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import AuthMessage from '../app/authMessage.jsx'
+import './adminUiHeadingsPage.css'
+
+export default function AdminUiHeadingsPage() {
+  const title = 'UI Headings'
+  const heading = `${title} | Admin Control Panel`
+  const fullTitle = `${heading} | ACPC`
+  useEffect(() => {
+    document.title = fullTitle
+  }, [fullTitle])
+
+  const variants = Array.from({ length: 20 }, (_, i) => i + 1)
+
+  return (
+    <>
+      <h1>{heading}</h1>
+      <AuthMessage />
+      {variants.map(num => (
+        <section key={num} className={`heading-demo variant-${num}`}>
+          <h2>Variant {num} h2</h2>
+          <p>Example content under h2 variant {num}.</p>
+          <h3>Variant {num} h3</h3>
+          <p>Example content under h3 variant {num}.</p>
+        </section>
+      ))}
+    </>
+  )
+}

--- a/src/urlTree.json
+++ b/src/urlTree.json
@@ -15,6 +15,7 @@
         "path": "/admin/ui",
         "name": "UI",
         "children": [
+          { "path": "/admin/ui/headings", "name": "Headings", "children": [] },
           { "path": "/admin/ui/charts", "name": "Charts", "children": [] }
         ]
       }


### PR DESCRIPTION
## Summary
- add `/admin/ui/headings` with 20 minimalist collapsible h2/h3 button styles
- hook new page into admin routing and navigation
- document feature and bump version to 0.0.68

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3fcb33eb4832e89500a9a1036462e