### PR TITLE
style: enlarge collapsible heading triangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.67
+Current version: 0.0.68
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -114,6 +114,7 @@ _Only this section of the readme can be maintained using Russian language_
 16. Collapsible headings
  - [x] 16.1 Enable collapsible headings in admin pages
  - [x] 16.2 Adjust toggle size for h3 and remove hover border
+ - [x] 16.3 Увеличить и приподнять треугольники сворачивания для h2 и h3
 
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.66",
+  "version": "0.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.66",
+      "version": "0.0.68",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.67",
+  "version": "0.0.68",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1691,6 +1691,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.68",
+      "date": "2025-08-31",
+      "time": "14:04:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Enlarged and raised h2/h3 collapse triangles",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Увеличены и приподняты треугольники сворачивания h2/h3",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3272,6 +3294,28 @@
           "description": "Перед графиками аналитики добавлены сворачиваемые заголовки",
           "weight": 40,
           "type": "feat",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.68",
+      "date": "2025-08-31",
+      "time": "14:04:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Enlarged and raised h2/h3 collapse triangles",
+          "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Увеличены и приподняты треугольники сворачивания h2/h3",
+          "weight": 30,
+          "type": "style",
           "scope": "ui"
         }
       ]

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -35,9 +35,9 @@
 .acph-toggle {
   cursor: pointer;
   user-select: none;
-  font-size: 10px;
-  vertical-align: text-bottom;
-  margin-right: 5px;
+  font-size: 16px;
+  vertical-align: -0.2em;
+  margin-right: 8px;
   border: none;
   border-radius: 0;
   padding: 0;
@@ -47,7 +47,7 @@
 }
 
 h3 > .acph-toggle {
-  font-size: 8px;
+  font-size: 14px;
 }
 
 .acph-toggle:hover {


### PR DESCRIPTION
## Summary
- enlarge and raise h2/h3 collapsible triangle toggles
- document new toggle size in README and bump version to 0.0.68
- log release note for collapsible toggle size tweak

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4012d80d8832e9d66f45dad78ac16