### PR TITLE
style: raise h2/h3 collapse toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.68
+Current version: 0.0.69
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -115,6 +115,7 @@ _Only this section of the readme can be maintained using Russian language_
  - [x] 16.1 Enable collapsible headings in admin pages
  - [x] 16.2 Adjust toggle size for h3 and remove hover border
  - [x] 16.3 Увеличить и приподнять треугольники сворачивания для h2 и h3
+ - [x] 16.4 Raise collapse triangles for h2 and h3 for better alignment
 
 17. Сайдбар админа
  - [x] 17.1 Вести названия страниц в json-файле

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.68",
+  "version": "0.0.69",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1713,6 +1713,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.69",
+      "date": "2025-08-31",
+      "time": "14:20:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Raised h2/h3 collapse triangles for better alignment",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Повышено положение треугольников сворачивания h2/h3 для лучшего выравнивания",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3315,6 +3337,28 @@
         {
           "description": "Увеличены и приподняты треугольники сворачивания h2/h3",
           "weight": 30,
+          "type": "style",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.69",
+      "date": "2025-08-31",
+      "time": "14:20:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Raised h2/h3 collapse triangles for better alignment",
+          "weight": 20,
+          "type": "style",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Повышено положение треугольников сворачивания h2/h3 для лучшего выравнивания",
+          "weight": 20,
           "type": "style",
           "scope": "ui"
         }

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -36,7 +36,7 @@
   cursor: pointer;
   user-select: none;
   font-size: 16px;
-  vertical-align: -0.2em;
+  vertical-align: -0.35em;
   margin-right: 8px;
   border: none;
   border-radius: 0;
@@ -48,6 +48,7 @@
 
 h3 > .acph-toggle {
   font-size: 14px;
+  vertical-align: -0.25em;
 }
 
 .acph-toggle:hover {


### PR DESCRIPTION
## Summary
- lift collapse triangle buttons for h2 and h3
- record change in docs and release notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b403fab260832ea7492964ddc9272a