### PR TITLE
fix: adjust admin sidebar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.70
+Current version: 0.0.71
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -141,6 +141,10 @@ _Only this section of the readme can be maintained using Russian language_
 
 23. Admin subpages
  - [x] 23.1 Hide Subpages on the dashboard
+
+24. Admin sidebar links
+ - [x] 24.1 Restore metric links in the admin sidebar
+ - [x] 24.2 Remove root and login links from the admin sidebar
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.70",
+      "version": "0.0.71",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.70",
+  "version": "0.0.71",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1757,6 +1757,28 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.71",
+      "date": "2025-08-31",
+      "time": "15:11:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Restored analytics links and removed root and login from admin sidebar",
+          "weight": 40,
+          "type": "fix",
+          "scope": "navigation"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Вернули ссылки аналитики и убрали root и login из админского сайдбара",
+          "weight": 40,
+          "type": "fix",
+          "scope": "navigation"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3403,6 +3425,28 @@
         {
           "description": "Удалены ссылки метрик из сайдбара админа и закреплён logout над версией",
           "weight": 30,
+          "type": "fix",
+          "scope": "navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.71",
+      "date": "2025-08-31",
+      "time": "15:11:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Restored analytics links and removed root and login from admin sidebar",
+          "weight": 40,
+          "type": "fix",
+          "scope": "navigation"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Вернули ссылки аналитики и убрали root и login из админского сайдбара",
+          "weight": 40,
           "type": "fix",
           "scope": "navigation"
         }

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -56,11 +56,9 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
 
   const flatNodes = useMemo(() => flattenTree(urlTree), [])
   const hidden = new Set([
+    '/',
     '/admin',
-    '/admin/growth',
-    '/admin/engagement',
-    '/admin/reliability',
-    '/admin/revenue',
+    '/admin/login',
     '/admin/ui',
     '/admin/ui/charts'
   ])


### PR DESCRIPTION
## Summary
- show metric links again in admin sidebar
- hide root and login links from admin sidebar
- document change, bump version, and update release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4117f85dc832eaa707620cf0f1d99