### PR TITLE
fix: refine collapsible analytics headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.72
+Current version: 0.0.73
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -148,6 +148,10 @@ _Only this section of the readme can be maintained using Russian language_
 
 25. Growth page
  - [x] 25.1 Add collapsible headings to /admin/growth
+
+26. Analytics headings
+ - [x] 26.1 Replace h2 with h3 on growth, engagement, reliability and revenue pages
+ - [x] 26.2 Fix collapse range for h2/h3 on analytics pages
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.72",
+  "version": "0.0.73",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1801,6 +1801,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.73",
+      "date": "2025-08-31",
+      "time": "16:30:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Replaced h2 with h3 on analytics pages and fixed collapse range",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заменены заголовки h2 на h3 на страницах аналитики и исправлено сворачивание",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3490,6 +3512,28 @@
       "changes-ru": [
         {
           "description": "Добавлены сворачиваемые заголовки на странице роста",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.73",
+      "date": "2025-08-31",
+      "time": "16:30:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Replaced h2 with h3 on analytics pages and fixed collapse range",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заменены заголовки h2 на h3 на страницах аналитики и исправлено сворачивание",
           "weight": 30,
           "type": "fix",
           "scope": "ui"

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -39,9 +39,9 @@ export default function useCollapsibleHeadings() {
 
     const build = () => {
       cleanup()
-      const headings = Array.from(main.querySelectorAll('h2, h3, h4'))
+      const headings = Array.from(main.querySelectorAll('h2, h3'))
       headings.forEach((heading, index) => {
-        const level = Number(heading.tagName.slice(1))
+        const tag = heading.tagName
         const button = document.createElement('button')
         button.type = 'button'
         button.className = 'acph-toggle'
@@ -50,10 +50,7 @@ export default function useCollapsibleHeadings() {
         button.textContent = collapsed ? '▶' : '▼'
         const targets = []
         let next = heading.nextElementSibling
-        while (
-          next &&
-          !(/H[2-4]/.test(next.tagName) && Number(next.tagName.slice(1)) <= level)
-        ) {
+        while (next && next.tagName !== tag) {
           targets.push(next)
           next = next.nextElementSibling
         }
@@ -87,7 +84,7 @@ export default function useCollapsibleHeadings() {
         if (
           mutations.some((m) =>
             Array.from(m.addedNodes).some(
-              (n) => n.querySelector && n.querySelector('h2, h3, h4')
+              (n) => n.querySelector && n.querySelector('h2, h3')
             )
           )
         ) {


### PR DESCRIPTION
## Summary
- improve collapsible hook to hide content until the next heading at the same level
- document analytics heading changes and bump version to 0.0.73

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b415e678e4832e973f5d84b285226a