### PR TITLE
fix: ensure analytics sections collapse fully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.72
+Current version: 0.0.73
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.72",
+  "version": "0.0.73",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1801,6 +1801,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.73",
+      "date": "2025-08-31",
+      "time": "16:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Ensured analytics headings collapse entire sections and standardized on h3",
+          "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заголовки аналитики сворачивают целые блоки и переведены на h3",
+          "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3491,6 +3513,28 @@
         {
           "description": "Добавлены сворачиваемые заголовки на странице роста",
           "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.73",
+      "date": "2025-08-31",
+      "time": "16:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Ensured analytics headings collapse entire sections and standardized on h3",
+          "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заголовки аналитики сворачивают целые блоки и переведены на h3",
+          "weight": 40,
           "type": "fix",
           "scope": "ui"
         }

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -39,9 +39,8 @@ export default function useCollapsibleHeadings() {
 
     const build = () => {
       cleanup()
-      const headings = Array.from(main.querySelectorAll('h2, h3, h4'))
+      const headings = Array.from(main.querySelectorAll('h2, h3'))
       headings.forEach((heading, index) => {
-        const level = Number(heading.tagName.slice(1))
         const button = document.createElement('button')
         button.type = 'button'
         button.className = 'acph-toggle'
@@ -50,10 +49,7 @@ export default function useCollapsibleHeadings() {
         button.textContent = collapsed ? '▶' : '▼'
         const targets = []
         let next = heading.nextElementSibling
-        while (
-          next &&
-          !(/H[2-4]/.test(next.tagName) && Number(next.tagName.slice(1)) <= level)
-        ) {
+        while (next && !/^H[1-6]$/.test(next.tagName)) {
           targets.push(next)
           next = next.nextElementSibling
         }
@@ -83,18 +79,10 @@ export default function useCollapsibleHeadings() {
 
     let observer
     if (window.MutationObserver) {
-      observer = new MutationObserver((mutations) => {
-        if (
-          mutations.some((m) =>
-            Array.from(m.addedNodes).some(
-              (n) => n.querySelector && n.querySelector('h2, h3, h4')
-            )
-          )
-        ) {
-          observer.disconnect()
-          build()
-          observer.observe(main, { childList: true, subtree: true })
-        }
+      observer = new MutationObserver(() => {
+        observer.disconnect()
+        build()
+        observer.observe(main, { childList: true, subtree: true })
       })
       observer.observe(main, { childList: true, subtree: true })
     }

--- a/src/admin/app/subPages.jsx
+++ b/src/admin/app/subPages.jsx
@@ -31,7 +31,7 @@ export default function SubPages() {
   if (children.length === 0) return null
   return (
     <div className="subpages">
-      <h2>Subpages</h2>
+      <h3>Subpages</h3>
       {renderTree(children)}
     </div>
   )


### PR DESCRIPTION
## Summary
- use h3 for admin Subpages heading
- collapse chart sections reliably by tracking all siblings and DOM changes
- document release

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b41c1d6f10832eb98503b1c69c5589