### PR TITLE
fix: collapse charts with headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.73
+Current version: 0.0.74
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.72",
+  "version": "0.0.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.72",
+      "version": "0.0.74",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.73",
+  "version": "0.0.74",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1823,6 +1823,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.74",
+      "date": "2025-08-31",
+      "time": "16:05:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Collapsing headings now hide charts on metric pages",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сворачивание заголовков скрывает графики на страницах метрик",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3535,6 +3557,28 @@
         {
           "description": "Заголовки аналитики сворачивают целые блоки и переведены на h3",
           "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.74",
+      "date": "2025-08-31",
+      "time": "16:05:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Collapsing headings now hide charts on metric pages",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сворачивание заголовков скрывает графики на страницах метрик",
+          "weight": 30,
           "type": "fix",
           "scope": "ui"
         }

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -59,29 +59,37 @@ export default function AdminGraphEngagementPage() {
       <h1>{heading}</h1>
       <section className="engagement-page__content">
         <h3>Sessions vs conversion</h3>
-        <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
-        <p>Goal: load vs conversion | Source: activity | Formula: signups/visits Δ to conversion | Period: all dates</p>
+        <div>
+          <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
+          <p>Goal: load vs conversion | Source: activity | Formula: signups/visits Δ to conversion | Period: all dates</p>
+        </div>
         <h3>Stickiness</h3>
-        <Line data={stickinessData} />
-        <p>Goal: product stickiness | Source: events | Formula: DAU/MAU | Period: all dates</p>
+        <div>
+          <Line data={stickinessData} />
+          <p>Goal: product stickiness | Source: events | Formula: DAU/MAU | Period: all dates</p>
+        </div>
         <h3>Cohort retention</h3>
-        <table className="engagement-page__table">
-          <thead><tr><th>Week</th><th>d+7</th><th>d+14</th><th>d+28</th></tr></thead>
-          <tbody>
-            {retention.map(r => (
-              <tr key={r.cohort}>
-                <td>{r.cohort}</td>
-                <td style={{ background: color(r.d7) }}>{(r.d7 * 100).toFixed(0)}%</td>
-                <td style={{ background: color(r.d14) }}>{(r.d14 * 100).toFixed(0)}%</td>
-                <td style={{ background: color(r.d28) }}>{(r.d28 * 100).toFixed(0)}%</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <p>Goal: cohort retention | Source: users | Formula: activity at d+N | Period: all cohorts</p>
+        <div>
+          <table className="engagement-page__table">
+            <thead><tr><th>Week</th><th>d+7</th><th>d+14</th><th>d+28</th></tr></thead>
+            <tbody>
+              {retention.map(r => (
+                <tr key={r.cohort}>
+                  <td>{r.cohort}</td>
+                  <td style={{ background: color(r.d7) }}>{(r.d7 * 100).toFixed(0)}%</td>
+                  <td style={{ background: color(r.d14) }}>{(r.d14 * 100).toFixed(0)}%</td>
+                  <td style={{ background: color(r.d28) }}>{(r.d28 * 100).toFixed(0)}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p>Goal: cohort retention | Source: users | Formula: activity at d+N | Period: all cohorts</p>
+        </div>
         <h3>Platform profile</h3>
-        <Bar data={profileData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
-        <p>Goal: platform profile | Source: users | Period: last 30 days</p>
+        <div>
+          <Bar data={profileData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
+          <p>Goal: platform profile | Source: users | Period: last 30 days</p>
+        </div>
       </section>
     </section>
   )

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -107,17 +107,25 @@ export default function AdminGraphGrowthPage() {
       <h1>{heading}</h1>
       <section className="growth-page__content">
         <h3>Active audience</h3>
-        <Line data={areaData} options={{ stacked: true }} />
-        <p>Goal: compare active audiences | Source: events | Formula: DAU/WAU/MAU/SMA7 | Period: all dates</p>
+        <div>
+          <Line data={areaData} options={{ stacked: true }} />
+          <p>Goal: compare active audiences | Source: events | Formula: DAU/WAU/MAU/SMA7 | Period: all dates</p>
+        </div>
         <h3>New vs returning</h3>
-        <Line data={newReturningData} options={{ stacked: true }} />
-        <p>Goal: share of new vs returning | Source: events | Formula: rule "new" | Period: all dates</p>
+        <div>
+          <Line data={newReturningData} options={{ stacked: true }} />
+          <p>Goal: share of new vs returning | Source: events | Formula: rule "new" | Period: all dates</p>
+        </div>
         <h3>Top of funnel</h3>
-        <Line data={funnelTopData} />
-        <p>Goal: upper funnel dynamics | Source: activity | Period: all dates</p>
+        <div>
+          <Line data={funnelTopData} />
+          <p>Goal: upper funnel dynamics | Source: activity | Period: all dates</p>
+        </div>
         <h3>Logins by weekday</h3>
-        <Bar data={weekdayData} />
-        <p>Goal: seasonality | Source: events | Formula: aggregate by weekday | Period: all dates</p>
+        <div>
+          <Bar data={weekdayData} />
+          <p>Goal: seasonality | Source: events | Formula: aggregate by weekday | Period: all dates</p>
+        </div>
       </section>
     </section>
   )

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -62,17 +62,25 @@ export default function AdminGraphReliabilityPage() {
       <h1>{heading}</h1>
       <section className="reliability-page__content">
         <h3>Error rate</h3>
-        <Line data={errRateData} />
-        <p>Goal: stability per session | Source: activity | Formula: errors/sessions | Period: all dates</p>
+        <div>
+          <Line data={errRateData} />
+          <p>Goal: stability per session | Source: activity | Formula: errors/sessions | Period: all dates</p>
+        </div>
         <h3>Error codes stack</h3>
-        <Line data={stackedErrorsData} options={{ stacked: true }} />
-        <p>Goal: incident structure | Source: activity | Formula: errors by code | Period: all dates</p>
+        <div>
+          <Line data={stackedErrorsData} options={{ stacked: true }} />
+          <p>Goal: incident structure | Source: activity | Formula: errors by code | Period: all dates</p>
+        </div>
         <h3>Pareto of errors</h3>
-        <Bar data={paretoData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
-        <p>Goal: 80/20 principle | Source: activity | Period: all dates</p>
+        <div>
+          <Bar data={paretoData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
+          <p>Goal: 80/20 principle | Source: activity | Period: all dates</p>
+        </div>
         <h3>Top error pages</h3>
-        <Bar data={pagesData} options={{ indexAxis: 'y' }} />
-        <p>Goal: problematic pages | Source: events | Formula: type=error aggregated | Period: all dates</p>
+        <div>
+          <Bar data={pagesData} options={{ indexAxis: 'y' }} />
+          <p>Goal: problematic pages | Source: events | Formula: type=error aggregated | Period: all dates</p>
+        </div>
       </section>
     </section>
   )

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -56,17 +56,25 @@ export default function AdminGraphRevenuePage() {
       <h1>{heading}</h1>
       <section className="revenue-page__content">
         <h3>Funnel conversion</h3>
-        <Bar data={funnelData} />
-        <p>Goal: step drop-off | Source: events | Formula: funnel totals | Period: all dates</p>
+        <div>
+          <Bar data={funnelData} />
+          <p>Goal: step drop-off | Source: events | Formula: funnel totals | Period: all dates</p>
+        </div>
         <h3>Paying segments</h3>
-        <Bar data={segData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
-        <p>Goal: paying segments | Source: events+users | Period: all subs</p>
+        <div>
+          <Bar data={segData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
+          <p>Goal: paying segments | Source: events+users | Period: all subs</p>
+        </div>
         <h3>Signups vs subscriptions</h3>
-        <Bar data={signupSubData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right' } } }} />
-        <p>Goal: inflow vs paid conversions | Source: activity+events | Period: all dates</p>
+        <div>
+          <Bar data={signupSubData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right' } } }} />
+          <p>Goal: inflow vs paid conversions | Source: activity+events | Period: all dates</p>
+        </div>
         <h3>Cumulative users</h3>
-        <Line data={cumulativeData} />
-        <p>Goal: user base growth | Source: users | Period: all dates</p>
+        <div>
+          <Line data={cumulativeData} />
+          <p>Goal: user base growth | Source: users | Period: all dates</p>
+        </div>
       </section>
     </section>
   )


### PR DESCRIPTION
## Summary
- hide charts when collapsing metric sections
- bump version to 0.0.74

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b41f2f8620832ead02b0d176ebdb81