### PR TITLE
feat: refine sidebars and persist metric state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.74
+Current version: 0.0.75
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -10,6 +10,7 @@ Current version: 0.0.74
 - Return to originally requested admin page after login
 - Public pages use a collapsible sidebar with icon tooltips and home link
 - Admin pages have a separate collapsible menu
+- Admin sidebar includes dashboard link and metric shortcut icons
 - Code split between `src/user` and `src/admin`
 - Admin pages (except the dashboard) display "Subpages" with a full URL tree when subpages exist
 - Navigation sidebars derive from the same tree; admin lists all URLs flat (no nested lists), public lists non-admin URLs
@@ -148,6 +149,16 @@ _Only this section of the readme can be maintained using Russian language_
 
 25. Growth page
  - [x] 25.1 Add collapsible headings to /admin/growth
+
+26. Admin sidebar icons
+ - [x] 26.1 Add dashboard link to admin sidebar
+ - [x] 26.2 Replace header icons with links to growth, engagement, reliability, and revenue
+
+27. User sidebar
+ - [x] 27.1 Remove extra header icons from user sidebar
+
+28. Metrics pages
+ - [x] 28.1 Persist collapsible state in localStorage
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.74",
+  "version": "0.0.75",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1845,6 +1845,52 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.75",
+      "date": "2025-09-01",
+      "time": "09:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added dashboard link and metric shortcuts to admin sidebar",
+          "weight": 40,
+          "type": "feat",
+          "scope": "navigation"
+        },
+        {
+          "description": "Trimmed user sidebar to keep only home icon",
+          "weight": 20,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Persisted metric page collapse state in local storage",
+          "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена ссылка на дашборд и ярлыки метрик в админский сайдбар",
+          "weight": 40,
+          "type": "feat",
+          "scope": "navigation"
+        },
+        {
+          "description": "Упрощён пользовательский сайдбар, оставлена только иконка дома",
+          "weight": 20,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Состояние свёрнутых секций метрик сохраняется в localStorage",
+          "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3579,6 +3625,52 @@
         {
           "description": "Сворачивание заголовков скрывает графики на страницах метрик",
           "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.75",
+      "date": "2025-09-01",
+      "time": "09:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Added dashboard link and metric shortcuts to admin sidebar",
+          "weight": 40,
+          "type": "feat",
+          "scope": "navigation"
+        },
+        {
+          "description": "Trimmed user sidebar to keep only home icon",
+          "weight": 20,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Persisted metric page collapse state in local storage",
+          "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлена ссылка на дашборд и ярлыки метрик в админский сайдбар",
+          "weight": 40,
+          "type": "feat",
+          "scope": "navigation"
+        },
+        {
+          "description": "Упрощён пользовательский сайдбар, оставлена только иконка дома",
+          "weight": 20,
+          "type": "fix",
+          "scope": "navigation"
+        },
+        {
+          "description": "Состояние свёрнутых секций метрик сохраняется в localStorage",
+          "weight": 40,
           "type": "fix",
           "scope": "ui"
         }

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -1,6 +1,13 @@
 import { useEffect, useState, useMemo } from 'react'
 import { Link, NavLink } from 'react-router-dom'
-import { Sidebar, Home, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
+import {
+  Sidebar,
+  Home,
+  TrendingUp,
+  Users,
+  Shield,
+  DollarSign
+} from 'react-feather'
 import pkg from '../../../package.json'
 import urlTree from '../../urlTree.json'
 import './barLeftAdmin.css'
@@ -57,7 +64,6 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
   const flatNodes = useMemo(() => flattenTree(urlTree), [])
   const hidden = new Set([
     '/',
-    '/admin',
     '/admin/login',
     '/admin/ui',
     '/admin/ui/charts'
@@ -91,18 +97,26 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
             <Link to="/" className="icon-button" title="Home">
               <Home size={16} />
             </Link>
-            <div className="icon-button" title="Columns">
-              <Columns size={16} />
-            </div>
-            <div className="icon-button" title="Calendar">
-              <Calendar size={16} />
-            </div>
-            <div className="icon-button" title="Check circle">
-              <CheckCircle size={16} />
-            </div>
-            <div className="icon-button" title="Cloud">
-              <Cloud size={16} />
-            </div>
+            <Link to="/admin/growth" className="icon-button" title="Growth">
+              <TrendingUp size={16} />
+            </Link>
+            <Link
+              to="/admin/engagement"
+              className="icon-button"
+              title="Engagement"
+            >
+              <Users size={16} />
+            </Link>
+            <Link
+              to="/admin/reliability"
+              className="icon-button"
+              title="Reliability"
+            >
+              <Shield size={16} />
+            </Link>
+            <Link to="/admin/revenue" className="icon-button" title="Revenue">
+              <DollarSign size={16} />
+            </Link>
           </>
         )}
       </div>

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -40,11 +40,12 @@ export default function useCollapsibleHeadings() {
     const build = () => {
       cleanup()
       const headings = Array.from(main.querySelectorAll('h2, h3'))
-      headings.forEach((heading, index) => {
+      headings.forEach(heading => {
+        const key = heading.textContent.trim()
         const button = document.createElement('button')
         button.type = 'button'
         button.className = 'acph-toggle'
-        let collapsed = state[index] === '1'
+        let collapsed = state[key] === '1'
         button.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
         button.textContent = collapsed ? '▶' : '▼'
         const targets = []
@@ -59,7 +60,7 @@ export default function useCollapsibleHeadings() {
           button.textContent = collapsed ? '▶' : '▼'
           button.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
           targets.forEach(t => t.classList.toggle('acph-collapsed', collapsed))
-          state[index] = collapsed ? '1' : '0'
+          state[key] = collapsed ? '1' : '0'
           saveState()
         }
         const keyHandler = (e) => {

--- a/src/user/app/barLeftUser.jsx
+++ b/src/user/app/barLeftUser.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
-import { Sidebar, Home, Columns, Calendar, CheckCircle, Cloud } from 'react-feather'
+import { Sidebar, Home } from 'react-feather'
 import urlTree from '../../urlTree.json'
 import './barLeftUser.css'
 
@@ -71,23 +71,9 @@ export default function BarLeftUser() {
           <Sidebar size={16} />
         </button>
         {!isCollapsed && (
-          <>
-            <Link to="/" className="icon-button" title="Home">
-              <Home size={16} />
-            </Link>
-            <div className="icon-button" title="Columns">
-              <Columns size={16} />
-            </div>
-            <div className="icon-button" title="Calendar">
-              <Calendar size={16} />
-            </div>
-            <div className="icon-button" title="Check circle">
-              <CheckCircle size={16} />
-            </div>
-            <div className="icon-button" title="Cloud">
-              <Cloud size={16} />
-            </div>
-          </>
+          <Link to="/" className="icon-button" title="Home">
+            <Home size={16} />
+          </Link>
         )}
       </div>
       {!isCollapsed && (


### PR DESCRIPTION
## Summary
- add dashboard link and metric shortcuts to admin sidebar
- persist collapse state on metric pages via heading keys
- streamline user sidebar to only show home icon

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4226e3b04832e9b9c29773af69d72