### PR TITLE
fix: persist metric collapse state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.75
+Current version: 0.0.76
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.74",
+  "version": "0.0.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.74",
+      "version": "0.0.76",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.75",
+  "version": "0.0.76",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1891,6 +1891,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.76",
+      "date": "2025-09-01",
+      "time": "10:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Fixed metric page collapse state not persisting after reload",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Исправлено несохранение состояния свёрнутых секций метрик после перезагрузки",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3671,6 +3693,28 @@
         {
           "description": "Состояние свёрнутых секций метрик сохраняется в localStorage",
           "weight": 40,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.76",
+      "date": "2025-09-01",
+      "time": "10:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Fixed metric page collapse state not persisting after reload",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Исправлено несохранение состояния свёрнутых секций метрик после перезагрузки",
+          "weight": 30,
           "type": "fix",
           "scope": "ui"
         }

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -35,6 +35,11 @@ export default function useCollapsibleHeadings() {
       })
       sections = []
       clearTimeout(saveTimer)
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(state))
+      } catch {
+        /* ignore */
+      }
     }
 
     const build = () => {


### PR DESCRIPTION
## Summary
- ensure metric page collapse state flushes to localStorage on cleanup
- bump version to 0.0.76 and record release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4246bdd14832eab80feffc5b5fdd0