### PR TITLE
feat: use h2 headings on metric pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.77
+Current version: 0.0.78
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -17,7 +17,7 @@ Current version: 0.0.77
 - User and admin sidebars highlight the active link
 - Dashboard at `/admin` with mini charts for growth, engagement, reliability, and revenue
 - Detailed analytics pages at `/admin/*` for growth, engagement, reliability, and revenue
-- Analytics charts use collapsible h3 headings for easier browsing
+- Analytics charts use collapsible h2 headings for easier browsing
 - Chart.js users charts at `/admin/ui/charts`
 
 # ACP+Charts сomming soon

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.76",
+  "version": "0.0.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.76",
+      "version": "0.0.78",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.77",
+  "version": "0.0.78",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1935,6 +1935,28 @@
           "scope": "layout"
         }
       ]
+    },
+    {
+      "version": "0.0.78",
+      "date": "2025-09-01",
+      "time": "12:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Promoted metric headings from h3 to h2 on admin pages",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Повышены заголовки метрик с h3 до h2 на админских страницах",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3761,6 +3783,28 @@
           "weight": 40,
           "type": "fix",
           "scope": "layout"
+        }
+      ]
+    },
+    {
+      "version": "0.0.78",
+      "date": "2025-09-01",
+      "time": "12:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Promoted metric headings from h3 to h2 on admin pages",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Повышены заголовки метрик с h3 до h2 на админских страницах",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
         }
       ]
     }

--- a/src/admin/pages/adminGraphEngagementPage.jsx
+++ b/src/admin/pages/adminGraphEngagementPage.jsx
@@ -58,17 +58,17 @@ export default function AdminGraphEngagementPage() {
     <section className="engagement-page">
       <h1>{heading}</h1>
       <section className="engagement-page__content">
-        <h3>Sessions vs conversion</h3>
+        <h2>Sessions vs conversion</h2>
         <div>
           <Bar data={sessionsConvData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
           <p>Goal: load vs conversion | Source: activity | Formula: signups/visits Δ to conversion | Period: all dates</p>
         </div>
-        <h3>Stickiness</h3>
+        <h2>Stickiness</h2>
         <div>
           <Line data={stickinessData} />
           <p>Goal: product stickiness | Source: events | Formula: DAU/MAU | Period: all dates</p>
         </div>
-        <h3>Cohort retention</h3>
+        <h2>Cohort retention</h2>
         <div>
           <table className="engagement-page__table">
             <thead><tr><th>Week</th><th>d+7</th><th>d+14</th><th>d+28</th></tr></thead>
@@ -85,7 +85,7 @@ export default function AdminGraphEngagementPage() {
           </table>
           <p>Goal: cohort retention | Source: users | Formula: activity at d+N | Period: all cohorts</p>
         </div>
-        <h3>Platform profile</h3>
+        <h2>Platform profile</h2>
         <div>
           <Bar data={profileData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
           <p>Goal: platform profile | Source: users | Period: last 30 days</p>

--- a/src/admin/pages/adminGraphGrowthPage.jsx
+++ b/src/admin/pages/adminGraphGrowthPage.jsx
@@ -106,22 +106,22 @@ export default function AdminGraphGrowthPage() {
     <section className="growth-page">
       <h1>{heading}</h1>
       <section className="growth-page__content">
-        <h3>Active audience</h3>
+        <h2>Active audience</h2>
         <div>
           <Line data={areaData} options={{ stacked: true }} />
           <p>Goal: compare active audiences | Source: events | Formula: DAU/WAU/MAU/SMA7 | Period: all dates</p>
         </div>
-        <h3>New vs returning</h3>
+        <h2>New vs returning</h2>
         <div>
           <Line data={newReturningData} options={{ stacked: true }} />
           <p>Goal: share of new vs returning | Source: events | Formula: rule "new" | Period: all dates</p>
         </div>
-        <h3>Top of funnel</h3>
+        <h2>Top of funnel</h2>
         <div>
           <Line data={funnelTopData} />
           <p>Goal: upper funnel dynamics | Source: activity | Period: all dates</p>
         </div>
-        <h3>Logins by weekday</h3>
+        <h2>Logins by weekday</h2>
         <div>
           <Bar data={weekdayData} />
           <p>Goal: seasonality | Source: events | Formula: aggregate by weekday | Period: all dates</p>

--- a/src/admin/pages/adminGraphReliabilityPage.jsx
+++ b/src/admin/pages/adminGraphReliabilityPage.jsx
@@ -61,22 +61,22 @@ export default function AdminGraphReliabilityPage() {
   <section className="reliability-page">
       <h1>{heading}</h1>
       <section className="reliability-page__content">
-        <h3>Error rate</h3>
+        <h2>Error rate</h2>
         <div>
           <Line data={errRateData} />
           <p>Goal: stability per session | Source: activity | Formula: errors/sessions | Period: all dates</p>
         </div>
-        <h3>Error codes stack</h3>
+        <h2>Error codes stack</h2>
         <div>
           <Line data={stackedErrorsData} options={{ stacked: true }} />
           <p>Goal: incident structure | Source: activity | Formula: errors by code | Period: all dates</p>
         </div>
-        <h3>Pareto of errors</h3>
+        <h2>Pareto of errors</h2>
         <div>
           <Bar data={paretoData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right', ticks: { callback: v => v + '%' } } } }} />
           <p>Goal: 80/20 principle | Source: activity | Period: all dates</p>
         </div>
-        <h3>Top error pages</h3>
+        <h2>Top error pages</h2>
         <div>
           <Bar data={pagesData} options={{ indexAxis: 'y' }} />
           <p>Goal: problematic pages | Source: events | Formula: type=error aggregated | Period: all dates</p>

--- a/src/admin/pages/adminGraphRevenuePage.jsx
+++ b/src/admin/pages/adminGraphRevenuePage.jsx
@@ -55,22 +55,22 @@ export default function AdminGraphRevenuePage() {
     <section className="revenue-page">
       <h1>{heading}</h1>
       <section className="revenue-page__content">
-        <h3>Funnel conversion</h3>
+        <h2>Funnel conversion</h2>
         <div>
           <Bar data={funnelData} />
           <p>Goal: step drop-off | Source: events | Formula: funnel totals | Period: all dates</p>
         </div>
-        <h3>Paying segments</h3>
+        <h2>Paying segments</h2>
         <div>
           <Bar data={segData} options={{ scales: { x: { stacked: true, max: 100 }, y: { stacked: true } } }} />
           <p>Goal: paying segments | Source: events+users | Period: all subs</p>
         </div>
-        <h3>Signups vs subscriptions</h3>
+        <h2>Signups vs subscriptions</h2>
         <div>
           <Bar data={signupSubData} options={{ scales: { y: { position: 'left' }, y1: { position: 'right' } } }} />
           <p>Goal: inflow vs paid conversions | Source: activity+events | Period: all dates</p>
         </div>
-        <h3>Cumulative users</h3>
+        <h2>Cumulative users</h2>
         <div>
           <Line data={cumulativeData} />
           <p>Goal: user base growth | Source: users | Period: all dates</p>


### PR DESCRIPTION
## Summary
- promote admin metric subheadings from h3 to h2
- document h2 collapse headings and bump version to 0.0.78

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b428d2811c832e8c9a3a887ac57511