### PR TITLE
Fix admin sidebar toggle overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.78
+Current version: 0.0.79
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -162,6 +162,7 @@ _Only this section of the readme can be maintained using Russian language_
 
 29. Admin sidebar overflow
  - [x] 29.1 Fix layout width after collapsing and expanding sidebar
+ - [x] 29.2 Prevent horizontal scroll after collapsing and expanding sidebar again
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.78",
+  "version": "0.0.79",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1957,6 +1957,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.79",
+      "date": "2025-09-01",
+      "time": "13:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Fixed admin page overflow after sidebar toggle",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Исправлено переполнение админской страницы после переключения сайдбара",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3805,6 +3827,28 @@
           "weight": 20,
           "type": "fix",
           "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.79",
+      "date": "2025-09-01",
+      "time": "13:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Fixed admin page overflow after sidebar toggle",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Исправлено переполнение админской страницы после переключения сайдбара",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
         }
       ]
     }

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -1,11 +1,14 @@
+
 .layout {
   display: flex;
   width: 100%;
+  overflow-x: hidden;
 }
 
 .layout > main {
   flex: 1;
   padding: 16px;
+  min-width: 0;
 }
 
 .skip-link {


### PR DESCRIPTION
## Summary
- prevent admin layout from expanding past viewport when sidebar toggles
- record release note and bump version to 0.0.79

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42bb0df9c832eacf65cc46305e225