### PR TITLE
Default collapsed metric headings with persistent state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.79
+Current version: 0.0.80
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -159,6 +159,7 @@ _Only this section of the readme can be maintained using Russian language_
 
 28. Metrics pages
  - [x] 28.1 Persist collapsible state in localStorage
+ - [x] 28.2 Start metric headings collapsed by default
 
 29. Admin sidebar overflow
  - [x] 29.1 Fix layout width after collapsing and expanding sidebar

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.79",
+  "version": "0.0.80",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -1979,6 +1979,28 @@
           "scope": "layout"
         }
       ]
+    },
+    {
+      "version": "0.0.80",
+      "date": "2025-09-01",
+      "time": "14:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Collapsed metric headings by default and preserved their state",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заголовки метрик по умолчанию свернуты и сохраняют состояние",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3849,6 +3871,28 @@
           "weight": 30,
           "type": "fix",
           "scope": "layout"
+        }
+      ]
+    },
+    {
+      "version": "0.0.80",
+      "date": "2025-09-01",
+      "time": "14:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Collapsed metric headings by default and preserved their state",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Заголовки метрик по умолчанию свернуты и сохраняют состояние",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
         }
       ]
     }

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -3,6 +3,13 @@ import { useLocation } from 'react-router-dom'
 
 export default function useCollapsibleHeadings() {
   const { pathname, search } = useLocation()
+  const collapseByDefaultPaths = [
+    '/admin/growth',
+    '/admin/engagement',
+    '/admin/reliability',
+    '/admin/revenue'
+  ]
+  const collapseByDefault = collapseByDefaultPaths.includes(pathname)
 
   useLayoutEffect(() => {
     const main = document.querySelector('main')
@@ -50,7 +57,8 @@ export default function useCollapsibleHeadings() {
         const button = document.createElement('button')
         button.type = 'button'
         button.className = 'acph-toggle'
-        let collapsed = state[key] === '1'
+        const saved = state[key]
+        let collapsed = saved === '1' || (saved === undefined && collapseByDefault)
         button.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
         button.textContent = collapsed ? '▶' : '▼'
         const targets = []
@@ -97,6 +105,6 @@ export default function useCollapsibleHeadings() {
       if (observer) observer.disconnect()
       cleanup()
     }
-  }, [pathname, search])
+  }, [pathname, search, collapseByDefault])
 }
 


### PR DESCRIPTION
## Summary
- Collapse metric page headings by default and keep their state in localStorage
- Document default-collapsed metric headings and bump version to 0.0.80
- Record release notes for v0.0.80

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42d949ea4832ea630072ee4a04504