### PR TITLE
feat: allow heading click to toggle sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.81
+Current version: 0.0.82
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -167,6 +167,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 30. Admin sidebar indentation
  - [x] 30.1 Indent nested links relative to parent regardless of URL or name mode
+
+31. Collapsible headings
+ - [x] 31.1 Toggle sections when clicking on h2 and h3 titles
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.81",
+  "version": "0.0.82",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -2023,6 +2023,28 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.82",
+      "date": "2025-09-02",
+      "time": "09:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Allowed clicking on h2 and h3 titles to toggle collapsible sections",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Разрешено сворачивать секции кликом по заголовкам h2 и h3",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3937,6 +3959,28 @@
           "weight": 30,
           "type": "fix",
           "scope": "navigation"
+        }
+      ]
+    },
+    {
+      "version": "0.0.82",
+      "date": "2025-09-02",
+      "time": "09:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Allowed clicking on h2 and h3 titles to toggle collapsible sections",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui",
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Разрешено сворачивать секции кликом по заголовкам h2 и h3",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui",
         }
       ]
     }

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -34,10 +34,12 @@ export default function useCollapsibleHeadings() {
     }
 
     const cleanup = () => {
-      sections.forEach(({ button, targets, handler, keyHandler }) => {
+      sections.forEach(({ button, heading, targets, handler, keyHandler }) => {
         button.removeEventListener('click', handler)
         button.removeEventListener('keydown', keyHandler)
+        heading.removeEventListener('click', handler)
         button.remove()
+        heading.classList.remove('acph-heading')
         targets.forEach(t => t.classList.remove('acph-collapsed'))
       })
       sections = []
@@ -68,7 +70,8 @@ export default function useCollapsibleHeadings() {
           next = next.nextElementSibling
         }
         if (collapsed) targets.forEach(t => t.classList.add('acph-collapsed'))
-        const handler = () => {
+        const handler = (e) => {
+          e?.stopPropagation()
           collapsed = !collapsed
           button.textContent = collapsed ? '▶' : '▼'
           button.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
@@ -84,8 +87,10 @@ export default function useCollapsibleHeadings() {
         }
         button.addEventListener('click', handler)
         button.addEventListener('keydown', keyHandler)
+        heading.addEventListener('click', handler)
+        heading.classList.add('acph-heading')
         heading.insertBefore(button, heading.firstChild)
-        sections.push({ button, targets, handler, keyHandler })
+        sections.push({ button, heading, targets, handler, keyHandler })
       })
     }
 

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -57,3 +57,7 @@ h3 > .acph-toggle {
   filter: brightness(1.2);
 }
 
+.acph-heading {
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- make collapsible headers toggle when clicking on the h2/h3 text
- style headings as clickable and document the change
- bump version to 0.0.82

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b431f1e75c832e99c4195f447cd191