### PR TITLE
Enable heading clicks to toggle collapsible sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.81
+Current version: 0.0.82
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -167,6 +167,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 30. Admin sidebar indentation
  - [x] 30.1 Indent nested links relative to parent regardless of URL or name mode
+
+31. Collapsible headings
+ - [x] 31.1 Toggle sections by clicking heading
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.81",
+  "version": "0.0.82",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -2023,6 +2023,28 @@
           "scope": "navigation"
         }
       ]
+    },
+    {
+      "version": "0.0.82",
+      "date": "2025-09-01",
+      "time": "16:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Enabled metric sections to toggle by clicking their headings",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено переключение секций метрик по клику на их заголовки",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3937,6 +3959,28 @@
           "weight": 30,
           "type": "fix",
           "scope": "navigation"
+        }
+      ]
+    }
+    ,{
+      "version": "0.0.82",
+      "date": "2025-09-01",
+      "time": "16:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Enabled metric sections to toggle by clicking their headings",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Добавлено переключение секций метрик по клику на их заголовки",
+          "weight": 20,
+          "type": "fix",
+          "scope": "ui"
         }
       ]
     }

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -34,10 +34,12 @@ export default function useCollapsibleHeadings() {
     }
 
     const cleanup = () => {
-      sections.forEach(({ button, targets, handler, keyHandler }) => {
+      sections.forEach(({ button, heading, targets, handler, keyHandler, headingHandler }) => {
         button.removeEventListener('click', handler)
         button.removeEventListener('keydown', keyHandler)
+        heading.removeEventListener('click', headingHandler)
         button.remove()
+        heading.classList.remove('acph-heading')
         targets.forEach(t => t.classList.remove('acph-collapsed'))
       })
       sections = []
@@ -82,10 +84,16 @@ export default function useCollapsibleHeadings() {
             handler()
           }
         }
+        const headingHandler = (e) => {
+          if (e.target === button) return
+          handler()
+        }
         button.addEventListener('click', handler)
         button.addEventListener('keydown', keyHandler)
+        heading.addEventListener('click', headingHandler)
+        heading.classList.add('acph-heading')
         heading.insertBefore(button, heading.firstChild)
-        sections.push({ button, targets, handler, keyHandler })
+        sections.push({ button, heading, targets, handler, keyHandler, headingHandler })
       })
     }
 

--- a/src/admin/app/layout.css
+++ b/src/admin/app/layout.css
@@ -48,6 +48,10 @@
   transition: filter 0.2s;
 }
 
+.acph-heading {
+  cursor: pointer;
+}
+
 h3 > .acph-toggle {
   font-size: 14px;
 }


### PR DESCRIPTION
## Summary
- Toggle metric sections by clicking h2/h3 headings in addition to arrow button
- Add pointer styling for clickable headings
- Document new heading toggle feature and bump version to 0.0.82

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43610237c832eb567e6342f3eebf9