### PR TITLE
fix: resize charts after admin sidebar toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.82
+Current version: 0.0.83
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -170,6 +170,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 31. Collapsible headings
  - [x] 31.1 Toggle sections by clicking heading
+
+32. Sidebar toggle layout
+ - [x] 32.1 Resize charts after sidebar collapse/expand
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.78",
+  "version": "0.0.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.78",
+      "version": "0.0.83",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.82",
+  "version": "0.0.83",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -2045,6 +2045,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.83",
+      "date": "2025-09-01",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Resized charts after admin sidebar toggle to prevent overflow",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "После переключения сайдбара админа графики пересчитывают размеры без переполнения",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3981,6 +4003,28 @@
           "weight": 20,
           "type": "fix",
           "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.83",
+      "date": "2025-09-01",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Resized charts after admin sidebar toggle to prevent overflow",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "После переключения сайдбара админа графики пересчитывают размеры без переполнения",
+          "weight": 30,
+          "type": "fix",
+          "scope": "layout"
         }
       ]
     }

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useRef } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import {
   Sidebar,
@@ -10,6 +10,7 @@ import {
 } from 'react-feather'
 import pkg from '../../../package.json'
 import urlTree from '../../urlTree.json'
+import { ChartJS } from './chartSetup.js'
 import './barLeftAdmin.css'
 
 const flattenTree = (nodes, depth = 0) =>
@@ -82,15 +83,27 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
     localStorage.setItem('barLeftAdminShowNames', String(next))
   }
 
+  const asideRef = useRef(null)
+
   useEffect(() => {
-    const timer = setTimeout(() => {
-      window.dispatchEvent(new Event('resize'))
-    }, 310)
-    return () => clearTimeout(timer)
-  }, [isCollapsed])
+    const el = asideRef.current
+    if (!el) return
+    const handle = e => {
+      if (e.propertyName === 'width') {
+        Object.values(ChartJS.instances).forEach(chart => chart.resize())
+        window.dispatchEvent(new Event('resize'))
+      }
+    }
+    el.addEventListener('transitionend', handle)
+    return () => el.removeEventListener('transitionend', handle)
+  }, [])
 
   return (
-    <aside className={`sidebar-left ${isCollapsed ? 'collapsed' : ''}`} onMouseLeave={onMouseLeave}>
+    <aside
+      ref={asideRef}
+      className={`sidebar-left ${isCollapsed ? 'collapsed' : ''}`}
+      onMouseLeave={onMouseLeave}
+    >
       <div className="sidebar-header">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Resize Chart.js instances and dispatch window resize when admin sidebar width transition ends
- Bump version to 0.0.83 and log fix in release notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43b680d18832e89f77cb95f8f5e90