### PR TITLE
feat: stack admin dashboard charts vertically on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.82
+Current version: 0.0.83
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -170,6 +170,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 31. Collapsible headings
  - [x] 31.1 Toggle sections by clicking heading
+
+32. Responsive dashboard
+ - [x] 32.1 Stack dashboard charts vertically on small screens
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.82",
+  "version": "0.0.83",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -2045,6 +2045,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.83",
+      "date": "2025-09-01",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Stacked dashboard charts vertically on small screens",
+          "weight": 30,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Графики дашборда на мобильных выстраиваются вертикально",
+          "weight": 30,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3980,6 +4002,28 @@
           "description": "Добавлено переключение секций метрик по клику на их заголовки",
           "weight": 20,
           "type": "fix",
+          "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.83",
+      "date": "2025-09-01",
+      "time": "17:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Stacked dashboard charts vertically on small screens",
+          "weight": 30,
+          "type": "feat",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Графики дашборда на мобильных выстраиваются вертикально",
+          "weight": 30,
+          "type": "feat",
           "scope": "ui"
         }
       ]

--- a/src/admin/pages/adminDashboardPage.css
+++ b/src/admin/pages/adminDashboardPage.css
@@ -11,3 +11,14 @@
   border: 1px solid #ccc;
   padding: 0.5rem;
 }
+
+.dashboard-card canvas {
+  width: 100% !important;
+  height: auto !important;
+}
+
+@media (max-width: 600px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- stack dashboard charts vertically on small screens
- document responsive dashboard and bump version to 0.0.83
- log dashboard responsiveness in release notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43f4f1870832ea6681524765f44a8