### PR TITLE
fix: stretch sidebar height with content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.84
+Current version: 0.0.85
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -176,6 +176,9 @@ _Only this section of the readme can be maintained using Russian language_
 
 33. Sidebar toggle logic
  - [x] 33.1 Fix sidebar toggle logic
+
+34. Sidebar height
+ - [x] 34.1 Expand sidebar height to match main content
 
 # Bot instructions
 1. Always start by reading this file and the "Features ToDo" section here. Do not do anything from "Features ToDo" unless you have direct instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.84",
+      "version": "0.0.85",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.84",
+  "version": "0.0.85",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -2089,6 +2089,28 @@
           "scope": "sidebar"
         }
       ]
+    },
+    {
+      "version": "0.0.85",
+      "date": "2025-09-01",
+      "time": "19:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Sidebar now grows to match taller main content",
+          "weight": 30,
+          "type": "fix",
+          "scope": "sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сайдбар растягивается по высоте основного контента",
+          "weight": 30,
+          "type": "fix",
+          "scope": "sidebar"
+        }
+      ]
     }
   ],
   "releases": [
@@ -3983,8 +4005,8 @@
           "scope": "ui"
         }
       ]
-    }
-    ,{
+    },
+    {
       "version": "0.0.81",
       "date": "2025-09-01",
       "time": "15:00:00",
@@ -4005,8 +4027,8 @@
           "scope": "navigation"
         }
       ]
-    }
-    ,{
+    },
+    {
       "version": "0.0.82",
       "date": "2025-09-01",
       "time": "16:00:00",
@@ -4067,6 +4089,28 @@
         {
           "description": "Исправлено переключение сайдбара с учётом кликов вне, Escape и фокуса",
           "weight": 40,
+          "type": "fix",
+          "scope": "sidebar"
+        }
+      ]
+    },
+    {
+      "version": "0.0.85",
+      "date": "2025-09-01",
+      "time": "19:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Sidebar now grows to match taller main content",
+          "weight": 30,
+          "type": "fix",
+          "scope": "sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Сайдбар растягивается по высоте основного контента",
+          "weight": 30,
           "type": "fix",
           "scope": "sidebar"
         }

--- a/src/admin/app/barLeftAdmin.css
+++ b/src/admin/app/barLeftAdmin.css
@@ -1,7 +1,8 @@
 .sidebar-left {
   position: sticky;
   top: 0;
-  height: 100vh;
+  height: 100%;
+  min-height: 100vh;
   overflow-y: auto;
   overflow-x: hidden;
   width: 250px;

--- a/src/user/app/barLeftUser.css
+++ b/src/user/app/barLeftUser.css
@@ -1,7 +1,8 @@
 .sidebar-left {
   position: sticky;
   top: 0;
-  height: 100vh;
+  height: 100%;
+  min-height: 100vh;
   overflow-y: auto;
   overflow-x: hidden;
   width: 250px;


### PR DESCRIPTION
## Summary
- let user sidebar grow with taller pages
- let admin sidebar grow with taller pages
- record fix in docs and release notes

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4447b4558832eb9afaec0bbb96b9e