### PR TITLE
fix: enable heading toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.86
+Current version: 0.0.87
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
@@ -170,6 +170,7 @@ _Only this section of the readme can be maintained using Russian language_
 
 31. Collapsible headings
  - [x] 31.1 Toggle sections by clicking heading
+ - [x] 31.2 Fix toggle button for collapsible headings
 
 32. Responsive dashboard
  - [x] 32.1 Stack dashboard charts vertically on small screens

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpc",
-  "version": "0.0.85",
+  "version": "0.0.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpc",
-      "version": "0.0.85",
+      "version": "0.0.87",
       "dependencies": {
         "chart.js": "^4.5.0",
         "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.86",
+  "version": "0.0.87",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -2145,6 +2145,28 @@
           "scope": "sidebar"
         }
       ]
+    },
+    {
+      "version": "0.0.87",
+      "date": "2025-09-02",
+      "time": "10:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Fixed collapsible heading buttons responding to clicks",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Исправлены кнопки сворачивания заголовков, теперь реагируют на клики",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ]
     }
   ],
   "releases": [
@@ -4181,6 +4203,28 @@
           "weight": 40,
           "type": "fix",
           "scope": "sidebar"
+        }
+      ]
+    },
+    {
+      "version": "0.0.87",
+      "date": "2025-09-02",
+      "time": "10:00:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Fixed collapsible heading buttons responding to clicks",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Исправлены кнопки сворачивания заголовков, теперь реагируют на клики",
+          "weight": 30,
+          "type": "fix",
+          "scope": "ui"
         }
       ]
     }

--- a/src/admin/app/hooks/useCollapsibleHeadings.js
+++ b/src/admin/app/hooks/useCollapsibleHeadings.js
@@ -34,10 +34,9 @@ export default function useCollapsibleHeadings() {
     }
 
     const cleanup = () => {
-      sections.forEach(({ button, heading, targets, handler, keyHandler, headingHandler }) => {
-        button.removeEventListener('click', handler)
+      sections.forEach(({ button, heading, targets, handler, keyHandler }) => {
         button.removeEventListener('keydown', keyHandler)
-        heading.removeEventListener('click', headingHandler)
+        heading.removeEventListener('click', handler)
         button.remove()
         heading.classList.remove('acph-heading')
         targets.forEach(t => t.classList.remove('acph-collapsed'))
@@ -84,16 +83,11 @@ export default function useCollapsibleHeadings() {
             handler()
           }
         }
-        const headingHandler = (e) => {
-          if (e.target === button) return
-          handler()
-        }
-        button.addEventListener('click', handler)
         button.addEventListener('keydown', keyHandler)
-        heading.addEventListener('click', headingHandler)
+        heading.addEventListener('click', handler)
         heading.classList.add('acph-heading')
         heading.insertBefore(button, heading.firstChild)
-        sections.push({ button, heading, targets, handler, keyHandler, headingHandler })
+        sections.push({ button, heading, targets, handler, keyHandler })
       })
     }
 


### PR DESCRIPTION
## Summary
- ensure collapsible headings toggle when clicking either the button or heading
- document fix in task list and bump version to 0.0.87
- record fix in release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b44b04b360832e854245751feefb90