### PR TITLE
Restrict sidebar outside-click collapse to mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACP+Charts now
-Current version: 0.0.87
+Current version: 0.0.88
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acpc",
   "private": true,
-  "version": "0.0.87",
+  "version": "0.0.88",
   "type": "module",
   "engines": {
     "node": ">=20.19.0"

--- a/release-notes.json
+++ b/release-notes.json
@@ -2167,6 +2167,28 @@
           "scope": "ui"
         }
       ]
+    },
+    {
+      "version": "0.0.88",
+      "date": "2025-09-02",
+      "time": "10:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Restricted sidebar outside-click collapse to mobile devices",
+          "weight": 30,
+          "type": "fix",
+          "scope": "sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Ограничено сворачивание сайдбара по клику вне только мобильными устройствами",
+          "weight": 30,
+          "type": "fix",
+          "scope": "sidebar"
+        }
+      ]
     }
   ],
   "releases": [
@@ -4225,6 +4247,28 @@
           "weight": 30,
           "type": "fix",
           "scope": "ui"
+        }
+      ]
+    },
+    {
+      "version": "0.0.88",
+      "date": "2025-09-02",
+      "time": "10:15:00",
+      "timezone": "Asia/Bishkek",
+      "changes": [
+        {
+          "description": "Restricted sidebar outside-click collapse to mobile devices",
+          "weight": 30,
+          "type": "fix",
+          "scope": "sidebar"
+        }
+      ],
+      "changes-ru": [
+        {
+          "description": "Ограничено сворачивание сайдбара по клику вне только мобильными устройствами",
+          "weight": 30,
+          "type": "fix",
+          "scope": "sidebar"
         }
       ]
     }

--- a/src/admin/app/barLeftAdmin.jsx
+++ b/src/admin/app/barLeftAdmin.jsx
@@ -73,6 +73,7 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
 
   useEffect(() => {
     if (!isCollapsed) {
+      const isMobile = window.matchMedia('(max-width: 768px)').matches
       const handleClick = e => {
         if (
           sidebarRef.current &&
@@ -92,10 +93,10 @@ export default function BarLeftAdmin({ forceCollapsed = false, disableToggle = f
           localStorage.setItem('barLeftAdminCollapsed', 'true')
         }
       }
-      document.addEventListener('click', handleClick)
+      if (isMobile) document.addEventListener('click', handleClick)
       document.addEventListener('keydown', handleKey)
       return () => {
-        document.removeEventListener('click', handleClick)
+        if (isMobile) document.removeEventListener('click', handleClick)
         document.removeEventListener('keydown', handleKey)
       }
     }

--- a/src/user/app/barLeftUser.jsx
+++ b/src/user/app/barLeftUser.jsx
@@ -54,6 +54,7 @@ export default function BarLeftUser() {
 
   useEffect(() => {
     if (!isCollapsed) {
+      const isMobile = window.matchMedia('(max-width: 768px)').matches
       const handleClick = e => {
         if (
           sidebarRef.current &&
@@ -73,10 +74,10 @@ export default function BarLeftUser() {
           localStorage.setItem('barLeftUserCollapsed', 'true')
         }
       }
-      document.addEventListener('click', handleClick)
+      if (isMobile) document.addEventListener('click', handleClick)
       document.addEventListener('keydown', handleKey)
       return () => {
-        document.removeEventListener('click', handleClick)
+        if (isMobile) document.removeEventListener('click', handleClick)
         document.removeEventListener('keydown', handleKey)
       }
     }


### PR DESCRIPTION
## Summary
- prevent sidebar from collapsing on outside clicks unless viewport is mobile-sized
- bump version to 0.0.88 and record change in release notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b44fab9bfc832e9f0bb0eab4af69fc