### PR TITLE
Add 404 not found page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Current version: 0.0.88
 
 - Minimal React + Vite app with basic routing
 - Public pages: home and English release notes
+- 404 page for non-existent routes
 - Admin login at `/admin/login` using env credentials
 - Authenticated admins visiting `/admin/login` are redirected back to the previous page
 - Admin access to dashboard and analytics graphs

--- a/src/admin/app/routes.jsx
+++ b/src/admin/app/routes.jsx
@@ -5,6 +5,7 @@ import AdminGraphGrowthPage from '../pages/adminGraphGrowthPage.jsx'
 import AdminGraphEngagementPage from '../pages/adminGraphEngagementPage.jsx'
 import AdminGraphReliabilityPage from '../pages/adminGraphReliabilityPage.jsx'
 import AdminGraphRevenuePage from '../pages/adminGraphRevenuePage.jsx'
+import NotFoundPage from '../../notFoundPage.jsx'
 
 const adminRoutes = [
   { path: 'login', element: <AdminLoginPage />, label: 'Login' },
@@ -13,7 +14,8 @@ const adminRoutes = [
   { path: 'growth', element: <AdminGraphGrowthPage />, label: 'Growth' },
   { path: 'engagement', element: <AdminGraphEngagementPage />, label: 'Engagement' },
   { path: 'reliability', element: <AdminGraphReliabilityPage />, label: 'Reliability' },
-  { path: 'revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' }
+  { path: 'revenue', element: <AdminGraphRevenuePage />, label: 'Revenue' },
+  { path: "*", element: <NotFoundPage /> },
 ]
 
 export default adminRoutes

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import UserLayout from './user/app/layout.jsx'
 import AdminLayout from './admin/app/layout.jsx'
 import MainPage from './user/pages/mainPage.jsx'
 import ReleaseNotesPage from './user/pages/releaseNotesPage.jsx'
+import NotFoundPage from './notFoundPage.jsx'
 import adminRoutes from './admin/app/routes.jsx'
 
 const router = createBrowserRouter([
@@ -22,6 +23,7 @@ const router = createBrowserRouter([
     element: <AdminLayout />,
     children: adminRoutes,
   },
+  { path: "*", element: <NotFoundPage /> },
 ])
 
 createRoot(document.getElementById('root')).render(

--- a/src/notFoundPage.jsx
+++ b/src/notFoundPage.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom'
+
+export default function NotFoundPage() {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>404 - Page Not Found</h1>
+      <p>
+        The page you're looking for does not exist. Go back to <Link to="/">the home page</Link>.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add shared 404 page component
- route unmatched paths to the 404 page, including admin section
- document 404 behaviour in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b466d38158832e86fac80212bb4756